### PR TITLE
Implement ruleset to protect `main` branch and document trunk-based d…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,3 +144,16 @@ required, not shared via Git, not a substitute for the files above.
   it's the source of truth for "what's actually done," not git log alone.
 - Small, reviewable commits per work unit (see the WU table in
   `docs/fase3-execution-state.md`), not one large commit spanning several.
+- **Do not implement on `main`** (ADR 0019, [Trunk-Based
+  Development](https://trunkbaseddevelopment.com/)). Short-lived branches,
+  then a PR. GitHub requires the existing Tests check; required approvals
+  are 0 so no person can block another. Anyone with write can merge a green
+  PR. Branch names follow [Conventional Branch 1.1.0](https://conventionalbranch.org/):
+  prefer purpose prefixes (`feat`/`feature`, `fix`/`bugfix`, `hotfix`,
+  `chore`); agent prefixes (`cursor/`, `ai/`, …) are allowed; do not
+  enforce names in GitHub (`dependabot/*` stays). Commit messages follow
+  [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+  (`type(scope): description`; types `feat`/`fix`/`docs`/`chore`/`refactor`/`ci`/`test`/`perf`/`revert`).
+  Prefer squash merge. No `develop`. The owner commits, pushes the feature
+  branch, merges, and deploys. Cursor still does not commit, push, merge,
+  or deploy unless the owner explicitly asks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ required, not shared via Git, not a substitute for the files above.
 - **Do not implement on `main`** (ADR 0019, [Trunk-Based
   Development](https://trunkbaseddevelopment.com/)). Short-lived branches,
   then a PR. GitHub requires the existing Tests check; required approvals
-  are 0 so no person can block another. Anyone with write can merge a green
+  are 0 (see ADR 0019 for the Copilot-unattributed PR exception). Anyone with write can merge a green
   PR. Branch names follow [Conventional Branch 1.1.0](https://conventionalbranch.org/):
   prefer purpose prefixes (`feat`/`feature`, `fix`/`bugfix`, `hotfix`,
   `chore`); agent prefixes (`cursor/`, `ai/`, …) are allowed; do not

--- a/docs/23-testing-foundation.md
+++ b/docs/23-testing-foundation.md
@@ -266,7 +266,9 @@ PHP 8.3, `composer install` (respeta `config.platform.php` 8.2.0; sin
 `--ignore-platform-reqs`), `composer lint:php`, `composer audit --locked`,
 después `composer test:unit`. `actions/cache@v5` (Node 24). Dependabot
 abre PRs semanales de Composer y GitHub Actions; **sin auto-merge**. Cada
-PR corre este workflow y necesita revisión del propietario. `composer
+PR corre este workflow. GitHub exige el check, **no** approvals (ADR 0019:
+quien tenga write puede mergear con CI verde; nadie queda bloqueado
+esperando a otra persona). `composer
 audit --locked` detecta advisories; Dependabot propone actualizaciones.
 Alerts y Security Updates de GitHub: verificar en la UI del repositorio.
 Sin environment de producción, sin secretos FTPS, sin deploy. No cierra

--- a/docs/23-testing-foundation.md
+++ b/docs/23-testing-foundation.md
@@ -266,9 +266,9 @@ PHP 8.3, `composer install` (respeta `config.platform.php` 8.2.0; sin
 `--ignore-platform-reqs`), `composer lint:php`, `composer audit --locked`,
 después `composer test:unit`. `actions/cache@v5` (Node 24). Dependabot
 abre PRs semanales de Composer y GitHub Actions; **sin auto-merge**. Cada
-PR corre este workflow. GitHub exige el check, **no** approvals (ADR 0019:
-quien tenga write puede mergear con CI verde; nadie queda bloqueado
-esperando a otra persona). `composer
+PR corre este workflow. GitHub exige el check; approvals = 0 (ver ADR 0019
+sobre la regla por defecto de +1 approval para PRs de Copilot sin atribución).
+Quien tenga write puede mergear con CI verde; nadie queda bloqueado esperando
 audit --locked` detecta advisories; Dependabot propone actualizaciones.
 Alerts y Security Updates de GitHub: verificar en la UI del repositorio.
 Sin environment de producción, sin secretos FTPS, sin deploy. No cierra

--- a/docs/adr/0019-proteger-main-trunk-based.md
+++ b/docs/adr/0019-proteger-main-trunk-based.md
@@ -1,0 +1,202 @@
+# ADR 0019: Proteger `main` con ruleset y trunk-based ligero
+
+## Estado
+
+Aceptada
+
+## Fecha
+
+2026-08-24
+
+## Contexto
+
+`main` era la rama por defecto y recibía **push directo**. No había
+protección clásica ni [conjunto de reglas](https://docs.github.com/es/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets).
+GitHub mostraba el aviso *Your main branch isn't protected*. Quien tenía
+write (`refo44` admin, `cenfissclases-svg` write) podía force-pushear o
+borrar `main`.
+
+El repositorio es **público** (`refo44/demo-revistalogos`). Los rulesets de
+**rama** están disponibles en repos públicos con GitHub Free. Los rulesets
+de **inserción** (tamaño/ruta de archivo) no aplican aquí: son de plan Team
+sobre repos privados/internos, y no hacen falta.
+
+Hoy hay **un solo desarrollador activo**, pero el código también pertenece
+a los colaboradores con write. Si el desarrollador activo pierde el acceso,
+ellos deben poder seguir. Ellos no deben poder bloquearle, ni él a ellos.
+GitFlow (`develop`, ramas de release largas) no aplica. El modelo es
+[Trunk-Based Development](https://trunkbaseddevelopment.com/): un solo
+trunk, ramas cortas, CI antes de integrar. Los nombres de rama siguen
+[Conventional Branch 1.1.0](https://conventionalbranch.org/) y los
+mensajes de commit [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/),
+ambos como **convención de proceso**, no como regla de GitHub.
+
+`main` es el trunk y debe permanecer desplegable. Producción sigue
+**manual** (`workflow_dispatch`, ADR 0009); GitHub Pages sigue publicando
+el espejo estático en cada llegada a `main` (deliberado). El workflow
+`Tests` (`.github/workflows/test.yml`) ya corre en PR y en push a `main`.
+El check que GitHub reporta se llama
+`PHP lint, Composer audit, and unit (PHP 8.3)`.
+
+Este ADR no relitiga ADR 0009.
+
+## Decisión
+
+### 1. Trunk-Based Development (equipo pequeño)
+
+Un solo trunk: `main`. Integración por [ramas cortas + PR](https://trunkbaseddevelopment.com/short-lived-feature-branches/)
+(CI y registro del cambio **antes** de aterrizar). No se commitea directo
+a `main`: el ruleset lo impide para todos por igual.
+
+- Sin `develop`. Conventional Branch lista `develop` como nombre de trunk;
+  aquí **no se crea**. El único trunk es `main`.
+- Sin ramas de release largas. Se publica **desde el trunk** (ADR 0009:
+  `workflow_dispatch` eligiendo `main`). `release/` del spec existe; no
+  se usa como GitFlow.
+- Una rama = un cambio pequeño; se mergea en cuanto CI está verde.
+
+### 2. Nadie bloquea a nadie; nadie es irreemplazable en el merge
+
+El candado es el **check de Tests**, no una persona.
+
+- Approvals de GitHub = **0**. Ni CODEOWNERS, ni «el último que pusheó
+  debe ser aprobado por otro», ni un número de reviews que deje el merge
+  a merced de un revisor ausente.
+- Quien tenga **write** abre un PR, espera CI verde y mergea. El admin
+  (`refo44`) y el colaborador write recorren **el mismo camino**. Si uno
+  pierde el acceso, el otro sigue.
+- Un *Request changes* se puede descartar con permiso write (comportamiento
+  de GitHub). No se añade ninguna regla que lo convierta en veto permanente.
+- Lista de omisión del ruleset **vacía**. Nadie pushea directo a `main`,
+  tampoco el administrador. Emergencia: desactivar o borrar el ruleset,
+  no un bypass permanente para una cuenta.
+- **No** se subirá a 1 approval «cuando haya un segundo autor». Eso
+  permitiría que uno bloquee al otro y dejaría el repo parado si queda
+  una sola persona.
+
+Ajustar *Settings* del repo (ruleset, secretos, Pages) sigue exigiendo
+admin. Eso no impide mergear código. Trasladar el repo a una organización
+si la cuenta personal desaparece es un asunto de GitHub, fuera de este ADR.
+
+### 3. Conventional Branch 1.1.0 (convención, no ruleset)
+
+Estructura: `<type>/<description>`. Minúsculas, números, guiones; sin
+guiones ni puntos seguidos, iniciales ni finales; sin espacios ni
+guiones bajos.
+
+**Prefijos de propósito** (preferidos: describen el trabajo):
+
+`feat/` o `feature/` · `fix/` o `bugfix/` · `hotfix/` · `chore/`
+
+**Prefijos de agente** (permitidos; [v1.1.0](https://conventionalbranch.org/)):
+`cursor/`, `ai/`, `claude/`, `copilot/`, `codex/`. Preferir el prefijo de
+propósito cuando el tipo de trabajo sea claro (`chore/protect-main-ruleset`,
+no `cursor/protect-main-ruleset`).
+
+**Excepción documentada:** Dependabot usa `dependabot/…`. No está en la
+gramática del spec; se acepta y **no** se restringe por nombre en GitHub
+(un patrón `feat/*` rompería esos PRs).
+
+No se instala `commit-check` ni `commit-check-action` en esta unidad
+(YAGNI; Dependabot). Tampoco se añade una regla de metadatos de rama al
+ruleset.
+
+### 4. Conventional Commits 1.0.0 (convención, no linter)
+
+Formato: `<type>[optional scope]: <description>` según
+[Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+Cuerpo opcional (el *por qué*) tras una línea en blanco. `BREAKING CHANGE:`
+en footer, o `!` tras el tipo/ámbito.
+
+**Tipos de este repo:** `feat`, `fix` (significado del spec); además
+`docs`, `chore`, `refactor`, `ci`, `test`, `perf`, `revert` (conjunto
+Angular / `@commitlint/config-conventional`, ya usados en el historial).
+Ámbito opcional, en minúsculas, p. ej. `feat(plugin):`, `docs(adr):`.
+Descripción en minúsculas, imperativo, sin punto final.
+
+Esto **no** dispara un bump automático de SemVer ni un CHANGELOG generado.
+Las versiones de plugin/theme/`VERSION.md` siguen siendo explícitas.
+
+No se instala commitlint ni se añade `commit_message_pattern` al ruleset
+(rompería `Merge pull request #N` y no es el candado; el candado es Tests).
+Dependabot ya suele emitir `chore(deps): …`; se acepta.
+
+**Merge preferido: squash**, para que en `main` quede un solo mensaje
+convencional por PR (el FAQ del spec lo recomienda). Merge commit y rebase
+siguen permitidos en GitHub; el botón *Create a merge commit* no produce
+un asunto Conventional Commits y se evita cuando se pueda.
+
+### 5. Ruleset de rama
+
+No protección clásica (y no ambos: se apilarían y ganaría la versión más
+restrictiva). Nombre: `Protect main (trunk-based)`. Destino:
+`refs/heads/main`. Cumplimiento: **Activo**.
+
+Reglas:
+
+- bloquear borrado de `main`;
+- bloquear force-push (`non_fast_forward`);
+- exigir Pull Request; approvals = **0**;
+- exigir el check `PHP lint, Composer audit, and unit (PHP 8.3)`
+  (GitHub Actions, `integration_id` 15368);
+- **no** exigir que la rama esté al día con `main` al inicio.
+
+GitHub activa por defecto *Require an additional approval for unattributed
+Copilot pull requests*. Con 0 approvals **no tiene efecto**; se deja el
+default.
+
+Identificador: ruleset `21337399`
+([vista](https://github.com/refo44/demo-revistalogos/rules/21337399)).
+
+### 6. Agentes
+
+Cursor no commitea, no pushea, no mergea ni despliega salvo petición
+explícita del propietario. Nombra ramas según §3 y redacta mensajes
+según §4.
+
+## Alternativas consideradas
+
+| Alternativa | Motivo de descarte |
+| ----------- | ------------------ |
+| Protección clásica de rama | Menos flexible; el aviso de GitHub apunta a rulesets. |
+| Ruleset + protección clásica a la vez | Se superponen; aplica la regla más estricta y confunde. |
+| GitFlow / `develop` / release largas | Choca con [TBD](https://trunkbaseddevelopment.com/). |
+| Commit directo a `main` (TBD de equipo muy pequeño) | Sin PR no hay check obligatorio ni rastro; el aviso de GitHub no se cierra. |
+| 1 approval obligatorio | Uno puede bloquear al otro; si queda una sola persona, el repo se para. |
+| Bypass de administrador | `main` seguiría abierta para `refo44`; el colaborador no tiene el mismo camino. |
+| Restringir nombres de rama en el ruleset | Rompe `dependabot/*`; el spec se aplica por convención. |
+| `commit-check-action` / commitlint ahora | Dependencia de CI extra; no cubre Dependabot ni merge commits; YAGNI. |
+| Forzar patrón de mensaje en el ruleset | Rompe *Merge pull request #N*; el spec se aplica al commitear y al squash. |
+| Ruleset de inserción (push) | Plan Team / repos privados; no es el problema. |
+| Commits firmados / merge queue / CODEOWNERS | YAGNI; CODEOWNERS podría bloquear. |
+| Exigir rama al día (`strict`) | Rebase eterno con PRs de Dependabot apilados. |
+
+## Consecuencias
+
+**Beneficios:** no hay push directo a `main`; force-push y borrado
+bloqueados; cada cambio deja un PR y Tests verde. Write basta para seguir
+si una cuenta desaparece. Pages sigue automático **después del merge**.
+El deploy de producción no cambia.
+
+**Riesgos / costes:** con 0 approvals, write + CI verde = merge. Eso es
+deliberado (continuidad), no un defecto a «arreglar» con reviews
+obligatorias. Un `git push origin main` **falla** para todos. Los nombres
+`dependabot/*` no cumplen el spec; se toleran. El repo sigue bajo una
+cuenta personal: perder esa cuenta es un riesgo de GitHub, no de este
+ruleset.
+
+**Trabajo futuro:** activar «branch up to date» solo si el desfase se
+vuelve un problema. Borrar la rama al mergear es un ajuste de repo
+aparte. No añadir approvals obligatorias.
+
+## Referencias
+
+- [Trunk-Based Development](https://trunkbaseddevelopment.com/)
+- [Conventional Branch 1.1.0](https://conventionalbranch.org/)
+- [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+- [Acerca de los conjuntos de reglas](https://docs.github.com/es/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+- [Creación de conjuntos de reglas de un repositorio](https://docs.github.com/es/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
+- [Reglas disponibles](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
+- ADR 0009 (despliegue; no se modifica)
+- ADR 0018 / `docs/23-testing-foundation.md` (workflow `Tests`)
+- `docs/adr/BACKLOG.md` § Trabajo pendiente aceptado, ítem 2 (origen)

--- a/docs/adr/0019-proteger-main-trunk-based.md
+++ b/docs/adr/0019-proteger-main-trunk-based.md
@@ -142,8 +142,8 @@ Reglas:
 - **no** exigir que la rama esté al día con `main` al inicio.
 
 GitHub activa por defecto *Require an additional approval for unattributed
-Copilot pull requests*. Con 0 approvals **no tiene efecto**; se deja el
-default.
+Copilot pull requests*. Si está activa, suma +1 approval (0 → 1) para PRs
+de Copilot sin atribución; desactivarla si se quiere mantener 0 siempre.
 
 Identificador: ruleset `21337399`
 ([vista](https://github.com/refo44/demo-revistalogos/rules/21337399)).

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -129,7 +129,7 @@ Estado en el repo: `.github/workflows/deploy.yml` («Deploy to Hostinger») **el
 
 Trabajo **ya aceptado** y **no iniciado** (o no cerrado en producción). No es un ADR nuevo: las decisiones siguen en los ADR enlazados. Estados: **NEXT**, **PLANNED**, **DEFERRED**. Sin fechas ni puntos. Cursor no implementa, no commitea, no despliega desde esta lista.
 
-**Completado — no es backlog:** ADR 0017 WU1–WU6B (generación al publicar, enforcement configurable, default OFF). El bug Gutenberg `meta-box-loader` pertenece al hotfix **0.2.8**, no a WU7.
+**Completado — no es backlog:** ADR 0017 WU1–WU6B (generación al publicar, enforcement configurable, default OFF). El bug Gutenberg `meta-box-loader` pertenece al hotfix **0.2.8**, no a WU7. ADR [0019](0019-proteger-main-trunk-based.md) (ruleset de `main` activo; docs por PR).
 
 **No forma parte de ADR 0017 WU7:** backfill automático; regeneración al guardar un artículo; PDF de número; FSE; borrado permanente de PDFs históricos; regeneración masiva (salvo aprobación posterior aparte).
 
@@ -139,7 +139,7 @@ Trabajo **ya aceptado** y **no iniciado** (o no cerrado en producción). No es u
 
 #### 1. Checkpoint de producción — plugin 0.2.8
 
-**Estado:** NEXT (working tree; **no** desplegado).
+**Estado:** NEXT (en Git `d9bf6d2`; **no** desplegado).
 
 Hotfix de `revistalogos-core` **0.2.8**: Gutenberg REST publica y genera el PDF; el follow-up `meta-box-loader` no debe borrar `pdf_file`. Theme **0.2.1**. Proyecto **0.2.0**. Enforcement default **OFF**. Sin backfill. Producción sigue en **0.2.7** hasta deploy del propietario (`docs/fase3-execution-state.md`).
 
@@ -156,17 +156,9 @@ No es una feature nueva.
 
 #### 2. Proteger `main` + trunk-based ligero
 
-**Estado:** NEXT, **después** del checkpoint 0.2.8.
+**Estado:** HECHO (ruleset GitHub 2026-08-24; ADR [0019](0019-proteger-main-trunk-based.md)). Documentación de esta decisión entra por PR en `chore/protect-main-ruleset`.
 
-Un solo desarrollador hoy. Evitar GitFlow. `main` es el trunk y permanece desplegable. Implementar en ramas cortas.
-
-Ruleset de GitHub previsto para `main`: proteger `main`; bloquear force-push y borrado; exigir Pull Request; approvals requeridas = **0**; exigir el check Tests existente; **no** exigir branch up-to-date al inicio; sin merge queue; sin rama `develop`; sin ramas de release largas; sin CODEOWNERS; sin commits firmados salvo justificación posterior.
-
-Flujo: `feat/*` | `fix/*` | `chore/*` → PR pequeño + CI verde → `main`.
-
-Tras adoptarlo: no implementar directo en `main`; rama corta por WU. Cursor **sigue sin** commit, push, merge ni deploy; el propietario lo hace a mano.
-
-KISS/YAGNI. Aún no hay ADR; no relitiga ADR 0009.
+Ruleset `Protect main (trunk-based)` (`21337399`), activo, sin bypass. `main` exige PR; 0 approvals (nadie bloquea a nadie; write + CI verde basta); check `PHP lint, Composer audit, and unit (PHP 8.3)`; sin force-push ni borrado. TBD: ramas cortas, sin `develop`. Nombres: [Conventional Branch 1.1.0](https://conventionalbranch.org/). Mensajes: [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Ambos por convención, no en el ruleset. Preferir squash. Cursor **sigue sin** commit, push, merge ni deploy.
 
 ### PLANNED
 

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -158,7 +158,7 @@ No es una feature nueva.
 
 **Estado:** HECHO (ruleset GitHub 2026-08-24; ADR [0019](0019-proteger-main-trunk-based.md)). Documentación de esta decisión entra por PR en `chore/protect-main-ruleset`.
 
-Ruleset `Protect main (trunk-based)` (`21337399`), activo, sin bypass. `main` exige PR; 0 approvals (nadie bloquea a nadie; write + CI verde basta); check `PHP lint, Composer audit, and unit (PHP 8.3)`; sin force-push ni borrado. TBD: ramas cortas, sin `develop`. Nombres: [Conventional Branch 1.1.0](https://conventionalbranch.org/). Mensajes: [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Ambos por convención, no en el ruleset. Preferir squash. Cursor **sigue sin** commit, push, merge ni deploy.
+Ruleset `Protect main (trunk-based)` (`21337399`), activo, sin bypass. `main` exige PR; 0 approvals base (ver ADR 0019 sobre la regla de +1 approval para PRs de Copilot sin atribución); check `PHP lint, Composer audit, and unit (PHP 8.3)`; sin force-push ni borrado. Trunk-Based Development: ramas cortas, sin `develop`. Nombres: [Conventional Branch 1.1.0](https://conventionalbranch.org/). Mensajes: [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Ambos por convención, no en el ruleset. Preferir squash. Cursor **sigue sin** commit, push, merge ni deploy.
 
 ### PLANNED
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,7 @@ Usar `TEMPLATE.md` como punto de partida. Estructura mínima: Estado · Fecha ·
 | [0016](0016-topologia-hosting-cpanel.md) | Topología de hosting (cPanel cenfiss2) | Aceptada |
 | [0017](0017-generacion-automatica-pdf-articulo.md) | Generación automática del PDF de artículo al publicar | Aceptada |
 | [0018](0018-testing-foundation.md) | Testing Foundation (PHPUnit, Composer dev-only, Gherkin sin Behat) | Aceptada |
+| [0019](0019-proteger-main-trunk-based.md) | Proteger `main` — TBD, Conventional Branch/Commits, ruleset | Aceptada |
 
 > El backlog de decisiones a resolver, y el trabajo aceptado aún no hecho, se lleva en `docs/adr/BACKLOG.md`. Cada decisión resuelta añade su fila a esta tabla. El trabajo de implementación no retira la fila del ADR.
 

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -1,12 +1,12 @@
 ---
 phase: "Fase 3"
 status: "classic_in_production"
-current_work_unit: "revistalogos-core 0.2.8 Gutenberg pdf_file hotfix; owner review; no commit/push/deploy"
-current_branch: "main"
+current_work_unit: "ADR 0019 protect main (ruleset live); docs on chore/protect-main-ruleset"
+current_branch: "chore/protect-main-ruleset"
 last_verified_commit: "8ebc8ee"
 last_checkpoint_commit: "8ebc8ee"
 updated_at: "2026-08-24"
-next_action: "Owner commit of plugin 0.2.8. Production still runs 0.2.7 until owner deploys. Default OFF. No backfill. WU7 not started."
+next_action: "Owner commit+PR of ADR 0019 docs. Production still 0.2.7 until owner deploys 0.2.8. Default OFF. No backfill. WU7 not started."
 blocked: false
 ---
 
@@ -574,13 +574,18 @@ delta +1, no doble generación. Plugin **0.2.6** sin bump.
 Sin commit, push ni deploy. Activación en producción:
 decisión del propietario.
 
-**2026-08-24 (plugin 0.2.8 hotfix, working tree):** Gutenberg REST
-publish genera el PDF; el follow-up `meta-box-loader` ya no borra
-`pdf_file` (keep one-shot, solo esa petición). Quitar PDF en un
-save normal sigue limpiando de inmediato. Default OFF. Sin
-backfill. WU7 no iniciado. Producción permanece en **0.2.7**
-hasta el deploy del propietario. Theme **0.2.1**. Proyecto
-**0.2.0**. Sin commit, push ni deploy.
+**2026-08-24 (plugin 0.2.8 hotfix):** Gutenberg REST publish genera
+el PDF; el follow-up `meta-box-loader` ya no borra `pdf_file` (keep
+one-shot, solo esa petición). Quitar PDF en un save normal sigue
+limpiando de inmediato. Default OFF. Sin backfill. WU7 no iniciado.
+Commit en Git `d9bf6d2`. Producción permanece en **0.2.7** hasta el
+deploy del propietario. Theme **0.2.1**. Proyecto **0.2.0**.
+
+**2026-08-24 (ADR 0019, ruleset GitHub):** `main` protegida con
+ruleset `Protect main (trunk-based)` (`21337399`), activo, sin
+bypass. Exige PR + check Tests; 0 approvals; sin force-push ni
+borrado. Documentación en working tree de `chore/protect-main-ruleset`
+(sin commit hasta el propietario). No relitiga ADR 0009.
 
 ## Next exact action
 
@@ -590,11 +595,13 @@ Recuperación institucional **ya hecha** (Pages reales permanentes). Carga
 editorial real en proceso desde wp-admin (**no** completa). Docker local:
 `http://localhost:8080` (WordPress 7.1, PHP **8.3**).
 
-Siguiente acción priorizada — **commit manual del propietario del
-hotfix de plugin 0.2.8** (Gutenberg meta-box-loader no debe borrar
-el `pdf_file` generado). Producción sigue en **0.2.7** (payload
-roto para ese follow-up) hasta que el propietario despliegue 0.2.8.
-No activar la exigencia; sin backfill; WU7 no iniciado.
+Siguiente acción priorizada — **commit+PR del propietario de ADR 0019**
+(rama `chore/protect-main-ruleset`). El ruleset de `main` **ya está
+activo** (GitHub `21337399`; no es un commit). Plugin **0.2.8** ya está
+en Git (`d9bf6d2`); producción sigue en **0.2.7** hasta que el
+propietario despliegue. No activar la exigencia PDF; sin backfill;
+WU7 no iniciado. Tras mergear 0019: no pushear a `main`; ramas cortas
++ PR (ADR 0019).
 Trabajo pendiente aceptado (no duplicar aquí):
 `docs/adr/BACKLOG.md` § Trabajo pendiente aceptado.
 


### PR DESCRIPTION
…evelopment practices

- Introduced ADR 0019 to establish a ruleset for the `main` branch, preventing direct pushes and requiring pull requests with zero approvals.
- Updated documentation in `CLAUDE.md`, `fase3-execution-state.md`, and `BACKLOG.md` to reflect the new ruleset and its implications for development workflow.
- Emphasized the use of short-lived branches and adherence to Conventional Branching and Commits for better collaboration and code management.