### PR TITLE
Update testing documentation and introduce Copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,52 @@
+# Copilot code review — Revista LOGO ET SPES
+
+Pointer only. Do not invent policy. Priority: `content-source/` > `docs/` > ADRs.
+Does not replace ADR 0018, 0019, `docs/23`, `docs/24`, or `CLAUDE.md`.
+
+## How to comment
+
+- Spanish. Conventional Comments: `<label> (decoration): subject`.
+- Default `(non-blocking)`. `(blocking)` only for a real defect (security, broken test, ADR violation) — author guidance, not a GitHub merge lock.
+- Labels: `praise`, `nitpick`, `suggestion`, `issue`, `todo`, `question`, `thought`, `chore`, `note`, `typo`. At most one extra decoration (`security`, `test`, `if-minor`).
+- Leave a **Comment** review. The merge lock is CI `PHP lint, Composer audit, and unit (PHP 8.3)`. Approvals = 0 (ADR 0019).
+- KISS/YAGNI. Do not suggest `develop`, GitFlow, CODEOWNERS, commitlint, required reviews, extra runners, or changing deploy (manual `workflow_dispatch`, ADR 0009). Pages auto-publish after merge to `main` is deliberate.
+
+## Scope — do not demand
+
+- CPT/taxonomy/role registration in the theme (ADR 0005: plugin owns domain).
+- Article PDF generation in the theme; turning publication enforcement ON (ADR 0017; default OFF).
+- Dummy/demo fixtures as production truth (ADR 0004).
+- Fase 4 DOI/ORCID/ISSN validation or derived URLs (ADR 0013).
+
+## PHP / WordPress (if the diff touches plugin or theme PHP)
+
+Sanitize on input, escape on output; nonce + capability on state-changing actions; no raw SQL if a WP API exists; `function_exists()` / `class_exists()` when the theme calls the plugin.
+
+## Tests (docs/24 craft, docs/23 stack, ADR 0018)
+
+Apply only if the diff adds/changes tests or domain PHP. Do not request tests for docs-only, copy-only, or CI-yaml-only PRs.
+
+**Flag `(test)` when:**
+
+- New domain behavior with no failing test first (TDD).
+- Internals mocked: `expects()` / `createMock()` on policy, orchestrator, mappers; SUT mocked; WordPress functions mocked.
+- New runner or mock lib (Behat, Brain Monkey, WP_Mock, Mockery, Pest, Playwright).
+- WordPress booted in `tests/Unit/`; SUT assigned in `setUp()`; shared mutable `$this->…`.
+- Test named after a production method (`test_decide_pdf_action`) or numbered (`test_1`).
+- Asserts private methods, call order, coverage %, handbook behavior, or trivial getters.
+- `$sut` / `$use_case->execute()` hiding the business action.
+
+**Do not flag:**
+
+- Missing `tools/qa-*.sh` on a unit-only or docs-only PR.
+- Handwritten doubles that implement a public interface (`Recording_Article_Pdf_Renderer`) — preferred over `createMock()`.
+- Short tests without `// Arrange` labels if AAA is obvious.
+- PHPUnit names without the words Given/When/Then (`test_last_token_is_the_surname_used_in_citation_formats` is the convention).
+- Gherkin in Spanish without Behat (`.feature` is spec, not a runner).
+
+**Prefer:** sociable tests (real internal collaborators; double only renderer/FS/HTTP/clock); one relevant isolated `qa-*.sh` only when WordPress wiring changed.
+
+## Git (ADR 0019)
+
+Branches: `feat`/`fix`/`hotfix`/`chore` (or `cursor/`/`ai/`). `dependabot/*` is an exception.
+Commits: Conventional Commits (`feat`/`fix`/`docs`/`chore`/`refactor`/`ci`/`test`/`perf`/`revert`). Prefer squash.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ Tracked Git files are the durable source of truth. Local editor config is not.
 1. **`content-source/`** — canonical content/text. Never modify wording;
    use exactly as written.
 2. **`docs/`** — architecture, content model, IA, URL policy, implementation
-   order, testing strategy (`docs/23-testing-foundation.md`), etc. Must not
+   order, testing strategy (`docs/23-testing-foundation.md`,
+   `docs/24-project-testing-standard.md`), etc. Must not
    contradict content-source; if it does, content-source wins and the doc
    gets flagged for correction.
 3. **`docs/adr/`** — binding decisions (numbered ADRs + `BACKLOG.md`).
@@ -27,7 +28,8 @@ Tracked Git files are the durable source of truth. Local editor config is not.
    it explicitly rather than silently deviating.
 4. **This file (`CLAUDE.md`)** — agent-facing operational constraints. Must
    not contradict 1–3. Testing policy is **not** defined here in full: follow
-   `docs/23-testing-foundation.md` and ADR 0018.
+   `docs/23-testing-foundation.md`, `docs/24-project-testing-standard.md`
+   and ADR 0018.
 
 **`.cursor/` is gitignored by design.** Cursor rules a developer may keep
 locally are optional convenience mirrors only: not authoritative, not
@@ -122,7 +124,8 @@ required, not shared via Git, not a substitute for the files above.
   plugin `vendor/`, verify `ext-dom` and `ext-mbstring` on that
   existing 8.3 runtime; do not change CloudLinux PHP Selector,
   MultiPHP, or the hosting PHP version.
-- **Testing:** follow `docs/23-testing-foundation.md` and ADR 0018. New
+- **Testing:** follow `docs/23-testing-foundation.md`,
+  `docs/24-project-testing-standard.md` and ADR 0018. New
   domain behavior uses TDD. For PHP changes, before completion: (1) syntax
   gate `./tools/php-lint.sh` or `composer lint:php`; (2) Composer lockfile
   audit `composer audit:deps` (`composer audit --locked`); (3) relevant
@@ -154,6 +157,9 @@ required, not shared via Git, not a substitute for the files above.
   enforce names in GitHub (`dependabot/*` stays). Commit messages follow
   [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
   (`type(scope): description`; types `feat`/`fix`/`docs`/`chore`/`refactor`/`ci`/`test`/`perf`/`revert`).
-  Prefer squash merge. No `develop`. The owner commits, pushes the feature
+  Prefer squash merge. Review comments follow
+  [Conventional Comments](https://conventionalcomments.org/)
+  (`label (non-blocking): subject` by default). No `develop`. The owner
+  commits, pushes the feature
   branch, merges, and deploys. Cursor still does not commit, push, merge,
   or deploy unless the owner explicitly asks.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ El espejo beta es GitHub Pages (`pages.yml`). El workflow estático
 
 **Lint CSS:** `npm run lint:css`.
 
-**Tests (ADR 0018, `docs/23-testing-foundation.md`):** PHP syntax
+**Tests (ADR 0018, `docs/23-testing-foundation.md`, `docs/24-project-testing-standard.md`):** PHP syntax
 `./tools/php-lint.sh` / `composer lint:php` (`php -l` only). Composer
 lockfile audit: `composer audit:deps` (`composer audit --locked`; PHPUnit
 and its transitives only — not WordPress, npm, or hosting). Units:

--- a/docs/00-order-documents.md
+++ b/docs/00-order-documents.md
@@ -29,7 +29,8 @@ Todos los documentos de arquitectura del sitio se redactan en español. Los tér
 | **20** | Principios de maquetación | Ancho de lectura, ritmo vertical, uso del espacio en blanco, relación tipografía/imagen. Cierra el sistema visual antes de escribir HTML. |
 | **21** | Diagrama de recorrido del usuario | Diagrama Mermaid de flujos del visitante. Validación visual de 10-user-journey. |
 | **22** | Identificadores académicos | DOI (Crossref) y ORCID: validación, flujo de depósito, costes. Depende del modelo de contenido (03) y del orden de implementación (17); documenta ADR 0013. |
-| **23** | Pruebas | Testing Foundation (PHPUnit, `php -l`, Gherkin, TDD). Siguiente número libre; no reordena 18–22. |
+| **23** | Pruebas | Testing Foundation (PHPUnit, `php -l`, Gherkin, TDD). No reordena 18–22. |
+| **24** | Oficio de pruebas | Cómo escribir un test (sociable-first, BDD, AAA, dobles). Depende de 23. Siguiente número libre. |
 
 ---
 
@@ -64,6 +65,7 @@ Ningún documento puede depender de uno con número mayor. Las referencias cruza
 21. `21-user-journey-diagram`
 22. `22-identificadores-academicos-doi-orcid`
 23. `23-testing-foundation`
+24. `24-project-testing-standard`
 
 ---
 
@@ -125,5 +127,5 @@ Estos principios aplican independientemente del tipo de sitio (comunidad, autor,
 
 ---
 
-**Versión:** 1.0  
+**Versión:** 1.1  
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/17-implementation-order.md
+++ b/docs/17-implementation-order.md
@@ -212,7 +212,7 @@ El trámite administrativo con Crossref **no depende de que exista el theme** (A
 
 No forma parte del cierre de Fase 3 ni de Fase 4. **Hoy** el PDF de artículo se sube a mano y publicar **no** lo exige.
 
-**Testing Foundation: IMPLEMENTADA** (ADR 0018, `docs/23-testing-foundation.md`, PHPUnit 9.6, `composer test:unit`). ADR 0017 permanece **aceptado**. WU1–WU6B están en `revistalogos-core` (política, adaptador, orquestación, renderer Dompdf, persistencia, source HTML, composición explícita y enforcement de publicación configurable). El ajuste wp-admin **arranca en OFF** (opción ausente = OFF). OFF: publicar sin PDF sigue permitido. ON: PDF válido se conserva; si falta, se genera; si falla, se bloquea. Desplegar o actualizar **no** activa la exigencia. El PDF integral del número sigue siendo carga editorial manual. Ver ADR 0017.
+**Testing Foundation: IMPLEMENTADA** (ADR 0018, `docs/23-testing-foundation.md`, `docs/24-project-testing-standard.md`, PHPUnit 9.6, `composer test:unit`). ADR 0017 permanece **aceptado**. WU1–WU6B están en `revistalogos-core` (política, adaptador, orquestación, renderer Dompdf, persistencia, source HTML, composición explícita y enforcement de publicación configurable). El ajuste wp-admin **arranca en OFF** (opción ausente = OFF). OFF: publicar sin PDF sigue permitido. ON: PDF válido se conserva; si falta, se genera; si falla, se bloquea. Desplegar o actualizar **no** activa la exigencia. El PDF integral del número sigue siendo carga editorial manual. Ver ADR 0017.
 
 ---
 

--- a/docs/23-testing-foundation.md
+++ b/docs/23-testing-foundation.md
@@ -18,7 +18,8 @@ explícita y enforcement de publicación configurable, default OFF).
 Fuente durable (Git), en este orden cuando hablen de pruebas:
 
 1. `content-source/` (texto editorial; no política de tests).
-2. `docs/` — este documento es la guía operativa de testing.
+2. `docs/` — este documento es la guía operativa de testing (taxonomía,
+   CI, comandos).
 3. `docs/adr/` — ADR 0018 (decisiones); ADR 0017 (PDF: renderer Dompdf
    real; persistencia y publicación WordPress no cableadas).
 4. `CLAUDE.md` — resumen para agentes; apunta aquí, no duplica el manual.
@@ -178,9 +179,18 @@ Un test debe proteger al menos uno de: invariante de dominio; comportamiento
 observable; contrato de integración; permiso/seguridad; integridad de datos;
 fallo importante; regresión ocurrida o realista.
 
+Puerta de calidad: **conductual** (si cambia el comportamiento, cambia el
+resultado) e **insensible a la estructura** (un refactor equivalente no
+rompe el test). Preferir pruebas **sociables**: colaboradores internos
+reales; doblar solo sistemas externos. Cada test PHPUnit es plano y
+autocontenido: sin SUT asignado en `setUp()`, sin estado mutable
+compartido. Cuerpo Arrange-Act-Assert. Nombre
+`test_<observable_behavior>`.
+
 Evitar: constantes vs sí mismas; getters triviales; «WordPress hace lo que
 dice el handbook»; whitespace de markup; orden incidental de arrays; métodos
-privados; estructura interna de clases; tests solo para subir cobertura.
+privados; estructura interna de clases; tests solo para subir cobertura;
+`expects()` / orden de llamadas sobre colaboradores internos.
 
 Nombres: el comportamiento que falló (`test_last_token_is_the_surname_used_in_citation_formats`),
 no el nombre del método de producción. Sin numerar tests.
@@ -204,10 +214,13 @@ solo, repetido y en cualquier orden. Sin fixtures persistentes ocultos.
 
 ## Mocks
 
-Objetos reales simples en unitarios. Mockear límites significativos
-(renderer PDF, persistencia de adjuntos, servicio externo). No mockear la
-clase bajo prueba, value objects, ni cada función de WordPress. Si el
-comportamiento es de WordPress, integración real.
+Objetos reales simples en unitarios. Doblar solo límites significativos
+(renderer PDF, persistencia de adjuntos, servicio externo). Preferir una
+clase pequeña que implementa la interfaz pública (doble de grabación) a
+`$this->createMock()`. No mockear la clase bajo prueba, value objects,
+colaboradores internos de dominio, ni cada función de WordPress. Si el
+comportamiento es de WordPress, integración real. No instalar Mockery,
+Brain Monkey, WP_Mock ni Pest.
 
 ## Base de datos, archivos, red
 
@@ -322,5 +335,5 @@ matriz de versiones) solo con necesidad arquitectónica demostrada. ADR 0017
 work unit 1 ya tiene la política pura; no adelantar `PdfGenerator` ni
 librerías PDF hasta la unidad de renderer.
 
-**Versión:** 1.0
+**Versión:** 1.1
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/24-project-testing-standard.md
+++ b/docs/24-project-testing-standard.md
@@ -1,0 +1,686 @@
+# Estándar de pruebas del proyecto
+
+Oficio para escribir tests en Revista de Filosofía LOGO ET SPES (PHP /
+WordPress clásico). Complementa [23-testing-foundation](23-testing-foundation.md)
+(taxonomía, CI, comandos) y no reescribe [ADR 0018](adr/0018-testing-foundation.md).
+
+**Aplica a:** `tests/Unit/**/*Test.php`, `tests/Support/**/*.php`,
+`tests/Features/**/*.feature`, `tools/qa-*.sh`
+
+**`.cursor/` está gitignored a propósito.** Si un desarrollador mantiene
+reglas Cursor locales, son espejos opcionales: no son fuente de verdad, no
+se versionan, no se exigen en otros clones ni en CI.
+
+---
+
+## Referencia rápida
+
+| Pregunta | Respuesta por defecto |
+|----------|------------------------|
+| ¿Qué tipo de test primero? | **Sociable** — colaboradores internos reales; doblar solo sistemas externos |
+| ¿Qué asertar? | **Resultados observables** por métodos públicos, HTTP o comportamiento wp-admin |
+| ¿Qué evitar? | `expects()` / `method()` / orden de llamadas sobre colaboradores **internos** |
+| ¿Cómo estructurar? | Plano, autocontenido, nombre de comportamiento + cuerpo AAA, sin estado mutable compartido |
+| ¿Cuándo arrancar WordPress? | Integración estrecha/amplia vía `tools/qa-*.sh` aislado — no en cada unitario sociable |
+| ¿Cuándo vale un test solitario? | Lógica pura con ramificación compleja donde el aislamiento aclara |
+| ¿Puerta de calidad? | **Conductual** + **insensible a la estructura** |
+| ¿Cómo correr la suite? | `composer test` (lint + audit + units); **un** `tools/qa-*.sh` relevante si cambió WordPress |
+
+---
+
+## 0. Filosofía
+
+**Principio:** los tests deben **acoplarse al comportamiento** y
+**desacoplarse de la estructura**.
+
+Este proyecto exige:
+
+- Pruebas sociables por defecto (colaboradores internos reales)
+- Semántica BDD (Gherkin en español; nombres PHPUnit que enuncian el escenario)
+- Diseño error-first en dominio nuevo (TDD: RED → GREEN → REFACTOR)
+- Conciencia de frontera (WordPress, filesystem, HTTP, renderer, reloj)
+
+Los tests solitarios solo cuando estén justificados.
+
+### Desiderata
+
+Ningún test necesita todas las propiedades. **No ceder una propiedad sin
+recibir otra de mayor valor.**
+
+**Par primario (no negociable en sociables y solitarios):**
+
+- **Conductual** — si cambia el comportamiento, debe cambiar el resultado del test
+- **Insensible a la estructura** — si solo cambia la estructura, el resultado no debe cambiar
+
+**Propiedades de apoyo:**
+
+- **Aislado** / **componible** — mismo resultado con cualquier orden o subconjunto
+- **Determinista** — mismas entradas, mismos resultados
+- **Rápido** — milisegundos en nivel 1; no arrancar WordPress/Docker salvo que el objetivo lo exija
+- **Legible** — nombres y variables de negocio explican por qué existe el test
+- **Específico** — al fallar, el escenario y la causa deben ser obvios
+- **Automatizado** — nivel 1 en CI; harnesses de nivel 2/3 deterministas y seguros en local
+- **Escribible** — el coste debe ser proporcionado; preferir cableado sociable a coreografía de mocks
+
+**Diferidas a tipos concretos:**
+
+- **Inspirador** — pasar debe dar confianza; los sociables lo logran con colaboradores internos reales
+- **Predictivo** — todo verde debe aproximar aptitud de producción; QA Docker aislado y contratos en fronteras WordPress
+
+Validar comportamiento observable: reglas de negocio, errores, transiciones
+de estado, corrección de frontera, guards de publicación/capacidad/nonce
+cuando ese código cambia.
+
+No fragmentar el comportamiento de negocio en micro-unitarios granulares.
+
+Un test debe proteger al menos uno de: invariante de dominio; comportamiento
+observable; contrato de integración; permiso/seguridad; integridad de datos;
+fallo realista; regresión ocurrida o plausible.
+
+---
+
+## 1. Modelo de frontera del SUT (obligatorio)
+
+Definir el sujeto bajo prueba (SUT) y clasificar colaboradores:
+
+- Internos → reales por defecto (política de dominio, orquestador, mappers,
+  helpers del theme sin WordPress)
+- Externos → dobles (motor PDF, persistencia de adjuntos, HTTP, filesystem,
+  cola, reloj, azar, entorno)
+
+La frontera del SUT decide el tipo de test.
+
+No colapsar capas arquitectónicas en el test por conveniencia.
+
+El plugin posee el dominio; el theme, solo la presentación (ADR 0005). Un
+unitario puede incluir un helper del theme libre de WordPress
+(`revistalogos_split_name`). No registrar CPT/taxonomías/roles desde el
+theme, ni generar PDF de artículo en el theme (ADR 0017).
+
+No fingir APIs de WordPress cuando el objeto de la prueba **es** el
+comportamiento de WordPress. Eso es nivel 2/3: Docker aislado, WordPress 7.1
+real.
+
+### 1.1 Observación de frontera cambiada (upgrades de dependencia o adaptador)
+
+Si el cambio actualiza una librería o un adaptador (Dompdf, API de
+adjuntos, cliente HTTP), las pruebas de aceptación y regresión deben
+**observar esa frontera**.
+
+Exigido:
+
+- Conservar colaboradores internos reales que poseen el comportamiento
+  (política de publicación, orquestador, constructor de HTML fuente)
+- Doblar solo el sistema externo, o ejecutar la librería real in-process
+  cuando ese es el punto (`ArticlePdfDompdfRendererTest`)
+- Asertar resultados observables: decisión de publicación, bytes PDF
+  (`%PDF-`), asociación adjunto/`pdf_file`, HTTP, aviso wp-admin
+- Hacer deterministas los fallos con dobles controlados — nunca un servicio
+  externo realmente caído
+- Asertar el mapeo de fallo (bloquear publicación, seguir sin publicar,
+  conservar el contenido), no afirmaciones vagas de resiliencia
+
+Prohibido como evidencia de aceptación del upgrade:
+
+- Suites que mockean la librería actualizada o al colaborador que la usa
+- Tests de negocio adyacentes que nunca ejercitan la frontera cambiada
+- «Lint/suite en verde» como sustituto de observar la frontera
+- Aserciones de orden interno de llamadas
+
+Ejemplo de falsa confianza: un unitario que sustituye
+`Dompdf_Article_Pdf_Renderer` por un doble de grabación no acepta un
+upgrade de Dompdf, porque Dompdf no se ejecuta.
+`ArticlePdfDompdfRendererTest` más `tools/qa-article-pdf-renderer.sh` sí.
+
+---
+
+## 2. Selección de tipo de test (orden estricto)
+
+Correspondencia con los tres niveles de `docs/23-testing-foundation.md`:
+
+| Este estándar | Nivel | Dónde vive |
+|---------------|-------|------------|
+| Programador sociable / solitario | Nivel 1 | `tests/Unit/`, PHPUnit, sin WordPress |
+| Integración estrecha | Nivel 2 | `tools/qa-*.sh` aislado (contratos WordPress) |
+| Contrato / aceptación | Nivel 3 | Gherkin en `tests/Features/` + `tools/qa-*.sh` |
+| Integración amplia | Nivel 2/3 | Harnesses Docker aislados; nunca producción |
+
+`tests/Integration/` y `composer test:integration` **aún no existen**. No
+inventar un bootstrap PHPUnit/WordPress para evitar un harness. No instalar
+Behat, Brain Monkey, WP_Mock, Mockery, Pest ni Playwright sin necesidad
+arquitectónica (ADR 0018).
+
+### Sociable vs solitario
+
+- **Sociable:** el SUT con **colaboradores internos reales** cableados.
+- **Solitario:** el SUT aislado sustituyendo colaboradores por dobles.
+
+Por defecto, sociable. El solitario cambia resiliencia al refactor por
+aislamiento: usarlo solo si la frontera o la ramificación lo exigen.
+
+Doblar solo lo **lento, frágil o no determinista** (DB, FS, HTTP, colas,
+caché, entorno, reloj, azar, motor PDF cuando el SUT es orquestación y no
+render). No doblar colaboradores internos de dominio para «unit test» de
+delegación u orden de llamadas.
+
+### Orden de prioridad
+
+1. **Pruebas sociables** (por defecto, nivel 1)  
+   Colaboradores internos reales. Doblar solo sistemas externos.
+
+   Construcción:
+   - Preferir **construcción manual** del grafo del SUT en el test (o un helper puro)
+   - Cablear clases internas reales; no sustituirlas por mocks
+   - Invocar **solo métodos públicos**
+   - Asertar **resultados**, no cómo se llamó a colaboradores internos
+   - No definir `ABSPATH` e incluir WordPress Core; el bootstrap unitario
+     puede definir un `ABSPATH` dummy solo para cargar archivos que lo
+     comprueban
+
+   Anti-patrones (sensibles a la estructura, bajo valor):
+   - `$this->expects($this->once())->method('…')` sobre colaboradores internos
+   - Tests que se rompen si se renombra un método interno equivalente y el
+     comportamiento no cambia
+
+2. **Integración estrecha** (nivel 2)  
+   Cableado, mapping, adaptadores, configuración y transformación de
+   entrada **en WordPress real**.  
+   No llamar sistemas fuera de WordPress (host de producción, Crossref,
+   ORCID, CDN).  
+   `docker compose -p <proyecto-efímero>` pertenece aquí, no como arranque
+   de cada unitario sociable.  
+   Excepción conocida: `tools/qa-author-permalinks.sh` usa volúmenes
+   primarios; no copiar ese patrón.
+
+3. **Pruebas solitarias** (restringidas, nivel 1)  
+   Solo lógica pura con ramificación compleja donde el aislamiento aclara.  
+   Restricciones:
+   - No arrancar WordPress ni Docker
+   - No llamar `$wpdb`, `WP_Query`, REST ni APIs de media
+   - Solo clases o funciones planas
+   - Sustituir colaboradores externos por dobles
+   - Doblar solo contratos públicos; dobles mínimos y estables
+   - Seguir asertando resultados observables; no coreografía interna
+
+   Ejemplos justificados hoy: `Article_Pdf_Publication_Policy`,
+   `revistalogos_split_name`.
+
+4. **Tests de contrato**  
+   Forma y semántica de la frontera.  
+   Gherkin enuncia el contrato de negocio en español. PHPUnit o un harness
+   lo ejecuta.  
+   No asertar detalles internos. No poner selectores CSS, nombres de clase,
+   IDs de BD ni `sleep` en `.feature`.
+
+5. **Integración amplia** (nivel 3)  
+   Flujo editorial completo o infraestructura WordPress real.  
+   Determinista, aislada, segura en local. Nunca producción. Nunca importar
+   `fixtures seed` como verdad editorial (ADR 0004).
+
+### Intercambios esperados
+
+Elegir el tipo a propósito:
+
+- **Sociable / solitario (programador)** — escribible, rápido, específico,
+  conductual, insensible a la estructura. Puede ceder predictivo e
+  inspirador pleno; el sociable recupera inspiración con cableado real.
+- **Contrato (aceptación)** — semántica de frontera y corrección
+  conductual. Puede ceder velocidad y especificidad puntual.
+- **Integración amplia** — confianza predictiva e inspiradora en WordPress
+  real. Puede ceder velocidad y especificidad del fallo.
+
+Al revisar un test: ¿qué propiedades tiene? ¿cuáles le faltan? ¿es ese el
+intercambio buscado?
+
+### Ejemplo sociable
+
+Cablear colaboradores internos reales y asertar resultados. Doblar solo la
+frontera externa (renderer, persistencia, HTTP).
+
+```php
+public function test_missing_pdf_invokes_renderer_and_returns_artifact() {
+	// Arrange
+	$renderer         = new Recording_Article_Pdf_Renderer();
+	$renderer->output = "%PDF-generated\n";
+	$orchestrator     = new Article_Pdf_Generation_Orchestrator( $renderer );
+
+	// Act
+	$publication_outcome = $orchestrator->orchestrate(
+		Article_Pdf_Publication_Policy::GENERATE_REQUIRED,
+		'article-source-42'
+	);
+
+	// Assert
+	$this->assertSame( "%PDF-generated\n", $publication_outcome['artifact'] );
+	$this->assertSame(
+		Article_Pdf_Publication_Policy::PUBLICATION_ALLOWED,
+		$publication_outcome['publication_decision']
+	);
+}
+```
+
+No doblar `Article_Pdf_Publication_Policy` aquí: es colaborador interno. El
+test sigue válido si el orquestador delega en otro helper interno con el
+mismo keep/generate/block.
+
+Observar un **doble de grabación en la costura externa** (si el renderer se
+invocó) está permitido cuando *esa* es la regla de dominio («no debe
+empezar la generación»). No añadir `expects()` sobre el orquestador o la
+política.
+
+---
+
+## 3. Estructura BDD (obligatoria)
+
+Cada test sigue semántica BDD:
+
+- **Dado**: contexto del sistema
+- **Cuando**: disparador o acción
+- **Entonces**: resultado observable, incluidos fallos
+
+**Gherkin** (`tests/Features/`, español): el título más `Dado` / `Cuando` /
+`Entonces` debe permitir reconstruir el escenario. Un feature, un idioma.
+Behat no está instalado; ejecutan PHPUnit y los harnesses.
+
+**PHPUnit:** el nombre del método debe enunciar el comportamiento
+observable. Convención vigente:
+
+```text
+test_<observable_behavior>
+```
+
+Ejemplo: `test_last_token_is_the_surname_used_in_citation_formats`
+
+No nombrar tests por el método de producción (`test_decide_pdf_action`).
+No numerar (`test_1`). No exigir las palabras Given/When/Then en el nombre
+PHP.
+
+El docblock del método puede llevar el relato Dado-Cuando-Entonces si el
+nombre quedaría demasiado largo.
+
+Al introducir dominio nuevo, los escenarios de fallo deben existir antes o
+junto a los caminos felices (TDD). Tests que describen implementación en
+vez de comportamiento no son válidos.
+
+---
+
+## 4. Patrón AAA (obligatorio en el cuerpo)
+
+Arrange, Act, Assert estructura el código del test.
+
+BDD narra el escenario. AAA estructura el cuerpo.
+
+- Dado, Cuando, Entonces pueden aparecer en Gherkin, el nombre o el docblock.
+- Arrange, Act, Assert deben estructurar el cuerpo.
+- Los nombres describen comportamiento observable, no implementación.
+
+Comentarios Arrange / Act / Assert están permitidos y se animan cuando el
+cuerpo supera unas pocas líneas. Tests cortos pueden omitir las etiquetas
+si las tres fases siguen siendo evidentes.
+
+### Comentarios e higiene
+
+- Nada trivial, redundante o irrelevante.
+- No reiterar comportamiento obvio, sintaxis PHP ni el handbook de WordPress.
+- Comentarios solo para intención, bordes no obvios o significado de dominio.
+- AAA está permitido y se anima.
+- Cada método de test conserva un docblock de *qué comportamiento protege*,
+  no una paráfrasis del nombre.
+
+---
+
+## 5. Estructura (sin estado mutable compartido)
+
+No usar `setUp()` ni `setUpBeforeClass()` para asignar el SUT u otras
+propiedades mutables.  
+Cada método declara sus colaboradores.
+
+`setUp()` / `tearDown()` solo para limpieza, reset de dobles o (en
+harnesses) ciclo de vida del servidor.  
+`setUpBeforeClass()` / `tearDownAfterClass()` solo para configuración
+inmutable.
+
+Los unitarios actuales construyen `$policy`, `$orchestrator` y `$renderer`
+dentro de cada método. Conservarlo.
+
+### Estructura plana (obligatoria)
+
+- Una subclase de `PHPUnit\Framework\TestCase` por archivo, nombrada por el
+  clúster de comportamiento (`ArticlePdfPublicationPolicyTest`).
+- No anidar clases TestCase ni inventar suites describe/it.
+- Cada método autocontenido e independiente.
+- Sin `protected $orchestrator` mutado entre métodos.
+- Sin setup de suite más allá de `setUpBeforeClass()` inmutable.
+- `@dataProvider` está permitido si es puro, devuelve arrays frescos y cada
+  caso es un escenario nombrado completo — no un escondite de estado
+  mutable.
+
+**Prohibido:**
+
+- Propiedades mutables asignadas en `setUp()` para el SUT
+- Dependencia del orden de ejecución
+- Fixtures ocultos en la BD o `/tmp`
+- Depender de contenido editorial ya presente en el volumen WordPress
+  primario del desarrollador
+
+Beneficios: independencia real, sin estado compartido, lectura más simple,
+sin anidación, sin orden implícito.
+
+---
+
+## 6. Arranque WordPress / Docker (estricto)
+
+Arrancar WordPress solo cuando el objetivo exige cableado del framework
+(integración, REST, meta, caps, Media Library, wp-admin).
+
+Los sociables de negocio deben preferir **construcción manual** del SUT y
+colaboradores internos reales. Evitar Docker y WordPress si el escenario
+cabe en clases planas.
+
+No arrancar WordPress dentro de `tests/Unit/`.
+
+- Proyecto compose aislado + `down -v` si el harness muta datos.
+- No reutilizar los volúmenes primarios (`localhost:8080`) en tests nuevos
+  que mutan.
+- No apuntar harnesses a producción (`logo-et-spes.cenfiss.net`).
+- No ejecutar `wp revistalogos fixtures seed` en producción.
+- Identificadores dummy (`1234-5678`, `10.1234/les.*`, `0000-0000-*`) no
+  son verdad editorial (ADR 0004).
+
+Los solitarios no arrancan WordPress.
+
+---
+
+## 7. HTTP y wp-admin
+
+Las comprobaciones HTTP y de UX editorial viven en `tools/qa-*.sh` (curl,
+WP-CLI `eval`, sitio aislado).
+
+- Cada harness construye su propia URL (`http://localhost:<puerto-aislado>`).
+- Payloads en línea o vía WP-CLI; no depender de contenido residual.
+- No mezclar una llamada PHPUnit in-process y HTTP en vivo en el mismo
+  test de nivel 1 — no hay WordPress en nivel 1.
+
+No instalar Supertest, Pest ni un cliente HTTP PHP para imitar NestJS.
+
+---
+
+## 8. Datos y helpers
+
+Preferir duplicación pequeña a abstracciones que ocultan comportamiento.
+
+Los helpers deben ser puros, sin estado y devolver objetos frescos.
+
+Evitar factories globales, fixtures mutables compartidos y estado oculto.
+
+Factories y helpers compartidos al inicio del archivo (o en
+`tests/Support/`) solo si son puros, sin estado y devuelven valores
+frescos.
+
+No deben:
+
+- Arrancar WordPress ni capturar un compose en marcha
+- Guardar estado mutable
+- Reutilizar o mutar objetos compartidos
+
+Un doble de grabación que implementa una interfaz pública (véase §12)
+puede tener contadores por instancia. Construir una instancia **nueva** en
+cada test.
+
+Toda la preparación permanece en el test o en hooks inmutables permitidos.
+
+---
+
+## 9. Calidad y determinismo (estricto)
+
+Cada test aserta comportamiento observable significativo y falla solo por
+defectos reales.
+
+El par **conductual / insensible a la estructura** es la puerta de
+calidad: el test demuestra que el comportamiento cambió (o no) — no que el
+código se reorganizó.
+
+No:
+
+- Reiterar PHP o el handbook de WordPress Core
+- Probar internos del framework
+- Duplicar casos idénticos
+- Probar funciones triviales sin ramificación
+- Asertar métodos privados
+- Asertar orden o recuento de llamadas en colaboradores internos
+- Asertar caminos internos de cómputo
+- Espiar o mockear métodos internos o colaboradores internos del SUT
+- Escribir tests que fallan en refactors que preservan comportamiento
+- Asertar constantes contra sí mismas, getters triviales, whitespace de
+  markup, orden incidental de arrays o porcentaje de cobertura
+- Tomar snapshots enormes de HTML; en HTML, semántica, no layout
+
+Los tests deben ser:
+
+- Seguros en paralelo (aislados) — harnesses con nombre de proyecto y
+  puerto distintos
+- Agnósticos al orden (componibles)
+- Deterministas
+
+Evitar:
+
+- `sleep` arbitrario (sondeos acotados de «listo» en harnesses son
+  excepción operativa, no patrón PHPUnit)
+- Orden por reloj de pared
+- Condiciones de carrera
+- Azar sin semilla
+- Dependencia de la hora actual
+- Red real en la suite por defecto (`composer audit` es la excepción
+  documentada; no está garantizado offline)
+
+Si el tiempo afecta el comportamiento, pasar un timestamp explícito o un
+doble de reloj. No usar «dos posts creados en el mismo segundo» como orden.
+
+### 9.1 Ejecución de la suite (obligatorio)
+
+Esto no es un monorepo Jest. No importar una regla de heap de 8 GB. No
+agotar la máquina apilando QA Docker.
+
+| Regla | Requisito |
+|-------|-----------|
+| **Nivel 1 (gate por defecto)** | `composer test` o `./tools/run-phpunit.sh` — lint, audit del lockfile, suite unitaria completa. La suite es pequeña; correrla entera. |
+| **Nivel 2/3** | El `tools/qa-*.sh` **relevante** cuando cambió integración WordPress. Un harness a la vez. Cada uno debe hacer `down -v` y salir. |
+| **Prohibido** | BD de producción; volúmenes primarios en tests nuevos que mutan; todos los harnesses «por si acaso» en un cambio solo unitario; instalar runners extra por teatro de cobertura |
+| **CI** | `.github/workflows/test.yml` es lint + audit Composer (raíz y plugin) + `composer test:unit`. No corre `qa-*.sh`. No exigir Docker QA en un PR solo de docs o solo unitario. |
+
+Portátil sin PHP nativo: `./tools/php-lint.sh` y `./tools/run-phpunit.sh`
+(ADR 0014).
+
+---
+
+## 10. Nombres (contexto de negocio obligatorio)
+
+Seguir el nombrado WordPress PHP de `includes/` y `tests/Unit/`:
+
+- Clases de test: `PascalCase` + sufijo `Test` (`ArticlePdfPublicationPolicyTest`)
+- Métodos: `test_` + `snake_case` de comportamiento
+- Clases de producción: `Class_Name`; funciones/variables: `snake_case`
+
+Nombres descriptivos, reveladores de intención, legibles sin comentarios.
+
+Prohibidos identificadores crípticos: `$sut`, `$srv`, `$cfg`, `$resp`, `$usr`.
+
+Nombres de una letra solo en contadores de bucle muy pequeños.
+
+- Variables del SUT: nombres de dominio (`$publication_policy`,
+  `$generation_orchestrator`, `$dompdf_renderer`)
+- Nombres cortos inequívocos en un test diminuto son aceptables (`$policy`
+  dentro de `ArticlePdfPublicationPolicyTest`)
+- Dobles: terminan en rol (`$recording_renderer`, `$failing_renderer`,
+  `$clock_stub`)
+- Clientes HTTP/harness: descriptivos (`$base_url`, `$admin_user`)
+- Payloads: significado de dominio (`$spanish_article_html`,
+  `$article_without_pdf`)
+- Valores de retorno: rol (`$publication_outcome`, `$pdf_artifact`,
+  `$name_parts`)
+- Booleanos: empiezan por `is_`, `has_`, `should_` (`$has_valid_pdf`)
+- Helpers: orientados a acción (`make_recording_renderer`)
+- Factories: `make_x` (`make_spanish_article_html`)
+
+Evitar `$data`, `$input`, `$result`, `$response`, `$mock_data` si existe un
+nombre de dominio. Preferir `$publication_outcome` a `$result`.
+
+Nombres consistentes para el mismo concepto de dominio; no filtrar detalles
+de implementación.
+
+---
+
+## 11. Invocación de métodos de dominio
+
+Cuando el objeto bajo prueba es una **política, orquestador o acción de
+aplicación**, evitar patrones genéricos que ocultan la intención de
+negocio.
+
+Este proyecto no usa use cases NestJS con `execute()`. Los métodos públicos
+ya nombran la acción (`decide_pdf_action`, `orchestrate`, `render`,
+`revistalogos_split_name`). Conservarlo.
+
+**Permitido:** método público específico sobre una variable que nombra el
+objeto de dominio:
+
+```php
+$publication_outcome = $generation_orchestrator->orchestrate(
+	Article_Pdf_Publication_Policy::GENERATE_REQUIRED,
+	$article_source
+);
+```
+
+**Prohibido** cuando variable y método son ambos genéricos o engañosos:
+
+```php
+$outcome = $sut->execute( $input );
+$outcome = $use_case->run( $input );
+$outcome = $handler->handle( $input );
+```
+
+Reglas:
+
+- No introducir un wrapper genérico `execute()` en tests ni en producción
+  para imitar NestJS.
+- La intención de negocio debe inferirse del nombre de la variable **y**
+  del método público.
+- El nombre del test debe reflejar esa misma intención.
+
+---
+
+## 12. Dobles de prueba (contratos públicos manuscritos)
+
+PHPUnit es el único runner. **No añadir** `jest-mock-extended`, Mockery,
+Prophecy, Brain Monkey ni WP_Mock.
+
+Preferir **objetos reales**. Cuando haya que doblar un colaborador externo,
+preferir una **clase pequeña que implementa la interfaz pública** a
+`$this->createMock()`.
+
+Reglas:
+
+- Doblar **solo colaboradores externos** (renderer, persistencia, HTTP,
+  filesystem, reloj, env)
+- **No** doblar colaboradores internos en tests sociables (políticas,
+  orquestadores, mappers, validadores cableados dentro del SUT)
+- No mockear la clase bajo prueba
+- No mockear value objects
+- No mockear cada función de WordPress; si el comportamiento es WordPress,
+  usar un harness
+- No extender una clase de producción solo para anular un método, salvo
+  que esa clase sea la costura documentada y aún no exista interfaz
+
+### Preferido: doble manuscrito
+
+```php
+class Recording_Article_Pdf_Renderer implements Article_Pdf_Renderer {
+	public $invocations = 0;
+	public $last_source;
+	public $output = "%PDF-fake\n";
+
+	public function render( $source ) {
+		$this->invocations++;
+		$this->last_source = $source;
+		return $this->output;
+	}
+}
+```
+
+Patrón ya usado en `ArticlePdfGenerationOrchestratorTest`. Tipado al
+contrato público, obvio, e insensible a refactors internos del orquestador.
+
+### Mocks nativos PHPUnit (restringidos)
+
+`$this->createMock()` / `getMockBuilder()` solo cuando un doble manuscrito
+sería más grande que el test **y** el tipo doblado es frontera externa.
+Aun así, devolver valores; no escribir `expects($this->once())->method(…)`
+salvo que la llamada misma sea la regla de dominio observable en esa
+costura.
+
+### Evitar
+
+- Mockear `Article_Pdf_Publication_Policy` en un test del orquestador
+- Literales de objeto que no implementan la interfaz
+- Mocks parciales del SUT
+- Mocks de funciones WordPress (`\Brain\Monkey\Functions\when('get_post_meta')`)
+
+**Prohibido:**
+
+- Doblar colaboradores internos cuando el sociable debe cablear la instancia real
+- Mocks sobrespecificados de coreografía interna
+- Instalar una librería de mocking para «facilitar» los dobles
+
+Los dobles deben ser mínimos, limitados a sistemas externos y construidos
+de nuevo en cada test.
+
+### Razón
+
+- Encaja con ADR 0018 (sin Brain Monkey / Mockery / Pest)
+- Evita que el mock se convierta en una segunda implementación
+- Mantiene tests insensibles a la estructura
+- Una clase de grabación de diez líneas es más barata y clara que un DSL
+  de mock para un método
+
+---
+
+## 13. Qué no testear
+
+No testear:
+
+- Métodos privados
+- Orden interno de llamadas
+- Comportamiento de WordPress Core / handbook de plugins
+- Internos de ORM / `$wpdb`
+- One-liners triviales
+- Comportamiento puro del lenguaje PHP
+- Layout CSS y whitespace
+- Porcentaje de cobertura
+- Validación de identificadores de Fase 4 (DOI/ORCID/ISSN) — campos inertes
+  (ADR 0013)
+- Activar la exigencia de PDF al publicar como efecto de un deploy
+  (ADR 0017; el default sigue OFF)
+
+Solo comportamiento observable.
+
+---
+
+## Comandos canónicos
+
+Los comandos, el alcance de CI y la lista de harnesses están en
+[23-testing-foundation](23-testing-foundation.md). Resumen:
+
+```bash
+composer test              # lint → audit --locked → units; no qa-*.sh
+composer test:unit
+./tools/php-lint.sh
+./tools/run-phpunit.sh
+```
+
+`php -l` comprueba **sintaxis**. `composer audit --locked` comprueba
+**advisories del lockfile**. PHPUnit comprueba **comportamiento**.
+`qa-*.sh` comprueba **WordPress integrado**.
+
+---
+
+**Versión:** 1.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,8 +34,9 @@ Documentación para el sitio web de la revista académica. CENFISS (Centro de Fi
 | 21 | user-journey-diagram | Diagrama Mermaid de recorridos |
 | 22 | identificadores-academicos-doi-orcid | Registro DOI (Crossref) y reconocimiento de autoría (ORCID): validación, flujo de depósito, costes |
 | 23 | testing-foundation | Testing Foundation: PHPUnit, taxonomía, Gherkin, TDD, harnesses QA, CI |
+| 24 | project-testing-standard | Oficio de pruebas: sociable-first, BDD, AAA, dobles manuscritos, qué no testear |
 
-Harness de Fase 3 (fuera de la numeración): `fase3-execution-state.md` (reanudación), `fase3-validation-matrix.md` (QA), `migracion-static-wordpress.md` (ledger ADR 0001–0003), `operations/` ([runbook de producción](operations/wordpress-manual-deployment.md), [snapshot](operations/produccion-wordpress.md), Docker, plugins de terceros). ADR de pruebas: [0018](adr/0018-testing-foundation.md).
+Harness de Fase 3 (fuera de la numeración): `fase3-execution-state.md` (reanudación), `fase3-validation-matrix.md` (QA), `migracion-static-wordpress.md` (ledger ADR 0001–0003), `operations/` ([runbook de producción](operations/wordpress-manual-deployment.md), [snapshot](operations/produccion-wordpress.md), Docker, plugins de terceros). ADR de pruebas: [0018](adr/0018-testing-foundation.md). Oficio: [24-project-testing-standard](24-project-testing-standard.md).
 
 ---
 
@@ -75,5 +76,5 @@ Ningún documento puede depender de uno con número mayor. Ver `00-order-documen
 
 ---
 
-**Versión:** 1.4
+**Versión:** 1.5
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/adr/0018-testing-foundation.md
+++ b/docs/adr/0018-testing-foundation.md
@@ -84,7 +84,13 @@ Nota factual 2026-08-22 (no cambia §1–§6): producción
 resolución Composer sigue **8.2.0**. `Requires PHP: 7.4` no se
 redefinió. PHPUnit 9.6 sin cambio de major.
 
+Nota factual 2026-08-24 (no cambia §1–§6): el oficio de cómo escribir un
+test vive en `docs/24-project-testing-standard.md`. Complementa `docs/23`
+(taxonomía, CI, comandos). No añade runners ni cambia PHPUnit 9.6, Gherkin
+sin Behat, ni la exclusión de Brain Monkey / Mockery / Pest.
+
 ## Referencias
 
 - `docs/23-testing-foundation.md` (reglas operativas)
+- `docs/24-project-testing-standard.md` (oficio: sociable-first, BDD, AAA, dobles)
 - ADR 0006, 0009, 0014, 0016, 0017

--- a/docs/adr/0019-proteger-main-trunk-based.md
+++ b/docs/adr/0019-proteger-main-trunk-based.md
@@ -154,6 +154,15 @@ Cursor no commitea, no pushea, no mergea ni despliega salvo petición
 explícita del propietario. Nombra ramas según §3 y redacta mensajes
 según §4.
 
+La revisión automática de Copilot (plan Pro, comentario, no bloquea)
+usa `.github/copilot-instructions.md`. Es un apuntador a estos ADR,
+no una segunda fuente de verdad.
+
+Los comentarios de review (humano o Copilot) siguen
+[Conventional Comments](https://conventionalcomments.org/):
+`<label> [decorations]: <subject>`. Por defecto `(non-blocking)`.
+`(blocking)` es guía para el autor, no un candado de GitHub.
+
 ## Alternativas consideradas
 
 | Alternativa | Motivo de descarte |
@@ -194,9 +203,12 @@ aparte. No añadir approvals obligatorias.
 - [Trunk-Based Development](https://trunkbaseddevelopment.com/)
 - [Conventional Branch 1.1.0](https://conventionalbranch.org/)
 - [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+- [Conventional Comments](https://conventionalcomments.org/)
 - [Acerca de los conjuntos de reglas](https://docs.github.com/es/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
 - [Creación de conjuntos de reglas de un repositorio](https://docs.github.com/es/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
 - [Reglas disponibles](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
 - ADR 0009 (despliegue; no se modifica)
 - ADR 0018 / `docs/23-testing-foundation.md` (workflow `Tests`)
 - `docs/adr/BACKLOG.md` § Trabajo pendiente aceptado, ítem 2 (origen)
+- [Copilot code review — instrucciones](https://docs.github.com/en/copilot/how-tos/copilot-on-github/use-copilot-agents/copilot-code-review#customize-reviews-with-custom-instructions)
+  (`.github/copilot-instructions.md`)

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -6,7 +6,7 @@ current_branch: "chore/add-copilot-review-instructions"
 last_verified_commit: "8ebc8ee"
 last_checkpoint_commit: "8ebc8ee"
 updated_at: "2026-08-24"
-next_action: "Owner commit+PR of .github/copilot-instructions.md. Production still 0.2.7 until owner deploys 0.2.8. Default OFF. No backfill. WU7 not started."
+next_action: "Owner deploys 0.2.8. Default OFF. No backfill. WU7 not started."
 blocked: false
 ---
 

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -1,12 +1,12 @@
 ---
 phase: "Fase 3"
 status: "classic_in_production"
-current_work_unit: "ADR 0019 protect main (ruleset live); docs on chore/protect-main-ruleset"
-current_branch: "chore/protect-main-ruleset"
+current_work_unit: "Add Copilot PR review instructions; ADR 0019 merged"
+current_branch: "chore/add-copilot-review-instructions"
 last_verified_commit: "8ebc8ee"
 last_checkpoint_commit: "8ebc8ee"
 updated_at: "2026-08-24"
-next_action: "Owner commit+PR of ADR 0019 docs. Production still 0.2.7 until owner deploys 0.2.8. Default OFF. No backfill. WU7 not started."
+next_action: "Owner commit+PR of .github/copilot-instructions.md. Production still 0.2.7 until owner deploys 0.2.8. Default OFF. No backfill. WU7 not started."
 blocked: false
 ---
 

--- a/tests/Features/README.md
+++ b/tests/Features/README.md
@@ -11,7 +11,8 @@ Language: **Spanish** (same as `docs/`). Do not mix English and Spanish
 inside one feature.
 
 Write observable business behavior, not class or method names. Rules:
-`docs/23-testing-foundation.md`.
+`docs/23-testing-foundation.md` (stack, CI, Gherkin location) and
+`docs/24-project-testing-standard.md` (how to write a test).
 
 ADR 0017 lives in `article-pdf-generation.feature` (business
 specification only; no Behat). Scenarios cover enforcement OFF


### PR DESCRIPTION
- Enhanced `CLAUDE.md`, `README.md`, and `docs/00-order-documents.md` to include references to the new `docs/24-project-testing-standard.md`, outlining the standards for writing tests.
- Added `docs/24-project-testing-standard.md` to provide comprehensive guidelines on test writing, complementing existing documentation.
- Introduced `.github/copilot-instructions.md` to guide Copilot code reviews, emphasizing the use of Conventional Comments and clarifying the review process.
- Updated `fase3-execution-state.md` to reflect the addition of Copilot review instructions and the current work unit.