### PR TITLE
fix(tools): reemplazar ripgrep por grep POSIX en los harnesses QA

### DIFF
--- a/tools/qa-article-editorial-ux.sh
+++ b/tools/qa-article-editorial-ux.sh
@@ -68,20 +68,20 @@ raise SystemExit(failed)
 PY
 pass "CTA and content-link contrast ratios meet AA"
 
-rg -q "\.btn--primary:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
+grep -Eq "\.btn--primary:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
 	|| fail "missing .btn--primary:visited component rule"
-rg -q "\.btn--pdf:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
+grep -Eq "\.btn--pdf:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
 	|| fail "missing .btn--pdf:visited component rule"
-rg -q "\.pagination__link:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
+grep -Eq "\.pagination__link:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
 	|| fail "missing .pagination__link:visited component rule"
-if rg -q "a:visited \{[^}]*color:\s*#fff" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/base.css"; then
+if grep -Eq "a:visited \{[^}]*color:[[:space:]]*#fff" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/base.css"; then
 	fail "must not globally force visited links to white"
 fi
-rg -q "a:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/base.css" \
+grep -Eq "a:visited" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/base.css" \
 	|| fail "ordinary a:visited rule must remain"
-rg -F -q "display: inline-flex" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
+grep -Fq "display: inline-flex" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css" \
 	|| fail ".btn must remain inline-flex (static wrap preflight for 320px / 200% zoom)"
-if rg -q "^\.btn[^_].*nowrap|\.btn \{[^}]*white-space:\s*nowrap" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css"; then
+if grep -Eq "^\.btn[^_].*nowrap|\.btn \{[^}]*white-space:[[:space:]]*nowrap" "$ROOT/wordpress/wp-content/themes/revistalogos/assets/css/components.css"; then
 	fail ".btn must not force nowrap (static wrap preflight for 320px / 200% zoom)"
 fi
 pass "CTA visited CSS is component-level; ordinary visited links preserved"
@@ -98,7 +98,7 @@ assert_contains() {
 	local file="$1"
 	local text="$2"
 
-	rg -F -q "$text" "$file" || fail "expected '$text' in $file"
+	grep -Fq "$text" "$file" || fail "expected '$text' in $file"
 }
 
 http_code() {
@@ -143,23 +143,23 @@ compose run --rm --entrypoint php wpcli -l wp-content/plugins/revistalogos-core/
 compose run --rm --entrypoint php wpcli -l wp-content/plugins/revistalogos-core/includes/fixtures/class-fixtures.php >/dev/null
 pass "PHP syntax of changed plugin files"
 
-rg -F -q "library: { type: 'application/pdf' }" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
+grep -Fq "library: { type: 'application/pdf' }" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
 	|| fail "PDF picker JS must filter application/pdf"
 pass "PDF picker JS filters application/pdf"
 
-rg -F -q "wp.apiFetch" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
+grep -Fq "wp.apiFetch" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
 	|| fail "author picker must use wp.apiFetch"
-rg -F -q "per_page" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
+grep -Fq "per_page" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
 	|| fail "author picker must bound per_page"
-rg -F -q "minLength" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
+grep -Fq "minLength" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/assets/js/admin-meta.js" \
 	|| fail "author picker must enforce minLength"
-if rg -q "use_block_editor_for_post_type" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php"; then
+if grep -Eq "use_block_editor_for_post_type" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php"; then
 	fail "plugin must not register use_block_editor_for_post_type"
 fi
 if [[ -f "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures/class-bootstrap-admin.php" ]]; then
 	fail "Bootstrap_Admin file must be absent"
 fi
-if rg -q "Bootstrap_Admin" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php"; then
+if grep -Eq "Bootstrap_Admin" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php"; then
 	fail "plugin must not wire Bootstrap_Admin"
 fi
 pass "Classic Editor override absent; Bootstrap_Admin absent; author picker uses core REST"
@@ -545,20 +545,20 @@ if [[ -s "$TMP/domain.err" ]]; then
 fi
 
 pass "domain eval finished"
-rg -q '^FAIL_COUNT=0$' "$TMP/domain.txt" || fail "domain FAIL_COUNT is not 0"
-if rg -q '^FAIL ' "$TMP/domain.txt"; then
+grep -Eq '^FAIL_COUNT=0$' "$TMP/domain.txt" || fail "domain FAIL_COUNT is not 0"
+if grep -Eq '^FAIL ' "$TMP/domain.txt"; then
 	fail "domain QA reported FAIL lines"
 fi
-if rg -q "Undefined property|PHP Warning|PHP Notice|PHP Deprecated" "$TMP/domain.txt" "$TMP/domain.err"; then
+if grep -Eq "Undefined property|PHP Warning|PHP Notice|PHP Deprecated" "$TMP/domain.txt" "$TMP/domain.err"; then
 	fail "domain eval emitted PHP warnings (see domain.txt / domain.err)"
 fi
 pass "authors, publication and PDF domain checks"
 
-ARTICLE1_ID="$(rg -o 'ARTICLE1=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-ARTICLE2_ID="$(rg -o 'ARTICLE2=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-MULTI_ID="$(rg -o 'MULTI=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-REAL_PDF="$(rg -o 'REAL_PDF=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-RAFAEL_ID="$(rg -o 'RAFAEL=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
+ARTICLE1_ID="$(grep -Eo 'ARTICLE1=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
+ARTICLE2_ID="$(grep -Eo 'ARTICLE2=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
+MULTI_ID="$(grep -Eo 'MULTI=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
+REAL_PDF="$(grep -Eo 'REAL_PDF=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
+RAFAEL_ID="$(grep -Eo 'RAFAEL=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
 
 echo "== Gutenberg REST HTTP =="
 APP_PASS="$(cli user application-password create "$ADMIN_USER" editorial-ux-qa --porcelain)"
@@ -607,16 +607,16 @@ assert_contains "$TMP/multi.html" "QA Second Author"
 assert_contains "$TMP/issue.html" "Rafael Eduardo Figueredo Oropeza"
 assert_contains "$TMP/issue.html" "QA Second Author"
 assert_contains "$TMP/rafael.html" "Rafael Eduardo Figueredo Oropeza"
-rg -q 'class="btn btn--pdf' "$TMP/a1.html" || fail "article PDF CTA uses btn btn--pdf"
-rg -q 'class="btn btn--primary' "$TMP/issue.html" || fail "issue PDF CTA uses btn btn--primary"
+grep -Eq 'class="btn btn--pdf' "$TMP/a1.html" || fail "article PDF CTA uses btn btn--pdf"
+grep -Eq 'class="btn btn--primary' "$TMP/issue.html" || fail "issue PDF CTA uses btn btn--primary"
 
 curl -sS "${BASE_URL}/wp-content/themes/revistalogos/assets/css/components.css?v=20260820-1" -o "$TMP/components.css"
-rg -q "\.btn--primary:visited" "$TMP/components.css" || fail "served components.css missing .btn--primary:visited"
-rg -q "\.btn--pdf:visited" "$TMP/components.css" || fail "served components.css missing .btn--pdf:visited"
+grep -Eq "\.btn--primary:visited" "$TMP/components.css" || fail "served components.css missing .btn--primary:visited"
+grep -Eq "\.btn--pdf:visited" "$TMP/components.css" || fail "served components.css missing .btn--pdf:visited"
 pass "served CTA CSS includes visited component rules"
 
 # article 2 has authors but no PDF after our tests? article2 never got a PDF.
-if rg -F -q "Descargar PDF del artículo" "$TMP/a2.html"; then
+if grep -Fq "Descargar PDF del artículo" "$TMP/a2.html"; then
 	fail "article 2 should not show PDF buttons"
 fi
 pass "frontend authors, TOC names, PDF href and citation_pdf_url"
@@ -624,7 +624,7 @@ pass "frontend authors, TOC names, PDF href and citation_pdf_url"
 # empty PDF buttons: editorial
 EDITORIAL_URL="$(cli post url "$(cli post list --post_type=article --name=editorial-vol-1-n-1 --format=ids)")"
 curl -sS "$EDITORIAL_URL" -o "$TMP/editorial.html"
-if rg -F -q "btn--pdf" "$TMP/editorial.html"; then
+if grep -Fq "btn--pdf" "$TMP/editorial.html"; then
 	fail "editorial without PDF should hide PDF buttons"
 fi
 pass "frontend PDF buttons hidden when empty"

--- a/tools/qa-article-editorial-ux.sh
+++ b/tools/qa-article-editorial-ux.sh
@@ -105,6 +105,13 @@ http_code() {
 	curl -sS -o /dev/null -w '%{http_code}' "$1"
 }
 
+# Read the numeric value of a `KEY=ID` line from a file. Uses awk (POSIX)
+# instead of `grep -Eo | cut`, since `-o` is a GNU/BSD extension, not POSIX.
+kv_id() {
+	local key="$1" file="$2"
+	awk -F= -v k="$key" '$1 == k { v = $2; gsub(/[^0-9].*/, "", v); print v; exit }' "$file"
+}
+
 echo "== isolated Docker environment =="
 compose down -v --remove-orphans >/dev/null 2>&1 || true
 compose up -d db wordpress
@@ -554,11 +561,11 @@ if grep -Eq "Undefined property|PHP Warning|PHP Notice|PHP Deprecated" "$TMP/dom
 fi
 pass "authors, publication and PDF domain checks"
 
-ARTICLE1_ID="$(grep -Eo 'ARTICLE1=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-ARTICLE2_ID="$(grep -Eo 'ARTICLE2=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-MULTI_ID="$(grep -Eo 'MULTI=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-REAL_PDF="$(grep -Eo 'REAL_PDF=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
-RAFAEL_ID="$(grep -Eo 'RAFAEL=[0-9]+' "$TMP/domain.txt" | cut -d= -f2)"
+ARTICLE1_ID="$(kv_id ARTICLE1 "$TMP/domain.txt")"
+ARTICLE2_ID="$(kv_id ARTICLE2 "$TMP/domain.txt")"
+MULTI_ID="$(kv_id MULTI "$TMP/domain.txt")"
+REAL_PDF="$(kv_id REAL_PDF "$TMP/domain.txt")"
+RAFAEL_ID="$(kv_id RAFAEL "$TMP/domain.txt")"
 
 echo "== Gutenberg REST HTTP =="
 APP_PASS="$(cli user application-password create "$ADMIN_USER" editorial-ux-qa --porcelain)"

--- a/tools/qa-article-editorial-ux.sh
+++ b/tools/qa-article-editorial-ux.sh
@@ -107,9 +107,15 @@ http_code() {
 
 # Read the numeric value of a `KEY=ID` line from a file. Uses awk (POSIX)
 # instead of `grep -Eo | cut`, since `-o` is a GNU/BSD extension, not POSIX.
+# Matching on the whole field (`$1 == k`) also avoids the substring match that
+# `grep -Eo 'KEY=[0-9]+'` would make on an unrelated `PREFIX_KEY=999` line.
+# A missing or non-numeric key aborts: awk alone would print nothing and exit
+# 0, leaving an empty ID to fail later somewhere less obvious.
 kv_id() {
-	local key="$1" file="$2"
-	awk -F= -v k="$key" '$1 == k { v = $2; gsub(/[^0-9].*/, "", v); print v; exit }' "$file"
+	local key="$1" file="$2" value
+	value="$(awk -F= -v k="$key" '$1 == k { v = $2; gsub(/[^0-9].*/, "", v); print v; exit }' "$file")"
+	[[ -n "$value" ]] || fail "missing or non-numeric $key in $file"
+	printf '%s\n' "$value"
 }
 
 echo "== isolated Docker environment =="

--- a/tools/qa-article-pdf-adapter.sh
+++ b/tools/qa-article-pdf-adapter.sh
@@ -41,13 +41,13 @@ trap cleanup EXIT
 echo "== static guards (no renderer, no generation APIs in adapter) =="
 ADAPTER="$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/article-pdf/class-article-pdf-wordpress-adapter.php"
 [[ -f "$ADAPTER" ]] || fail "Article_Pdf_WordPress_Adapter file missing"
-if rg -q "media_handle_sideload|wp_insert_attachment|wp_generate_attachment_metadata|wp_update_attachment_metadata" "$ADAPTER"; then
+if grep -Eq "media_handle_sideload|wp_insert_attachment|wp_generate_attachment_metadata|wp_update_attachment_metadata" "$ADAPTER"; then
 	fail "adapter must not create or update attachments"
 fi
-if rg -q "update_post_meta|add_post_meta|delete_post_meta|wp_update_post|wp_insert_post" "$ADAPTER"; then
+if grep -Eq "update_post_meta|add_post_meta|delete_post_meta|wp_update_post|wp_insert_post" "$ADAPTER"; then
 	fail "adapter must be read-only (no post/meta writes)"
 fi
-if rg -q "add_action|add_filter" "$ADAPTER"; then
+if grep -Eq "add_action|add_filter" "$ADAPTER"; then
 	fail "adapter must not register WordPress hooks"
 fi
 pass "adapter source has no write/hook/generation APIs"

--- a/tools/qa-article-pdf-composition.sh
+++ b/tools/qa-article-pdf-composition.sh
@@ -375,10 +375,10 @@ echo "== static guards (no persistence, hooks, or enforcement) =="
 [[ -f "$BUILDER" ]] || fail "Article_Pdf_WordPress_Source_Builder file missing"
 [[ -f "$GENERATOR" ]] || fail "Article_Pdf_WordPress_Generator file missing"
 [[ -f "$TEMPLATE" ]] || fail "Article_Pdf_Editorial_Template file missing"
-if rg -q "add_action|add_filter" "$BUILDER" "$GENERATOR" "$TEMPLATE"; then
+if grep -Eq "add_action|add_filter" "$BUILDER" "$GENERATOR" "$TEMPLATE"; then
 	fail "WU6A classes must not register WordPress hooks"
 fi
-if rg -q "wp_insert_post_data|rest_pre_insert|transition_post_status|register_setting|revistalogos_article_pdf_publication_enforcement" "$BUILDER" "$GENERATOR" "$TEMPLATE"; then
+if grep -Eq "wp_insert_post_data|rest_pre_insert|transition_post_status|register_setting|revistalogos_article_pdf_publication_enforcement" "$BUILDER" "$GENERATOR" "$TEMPLATE"; then
 	fail "WU6A classes must not wire publication or settings"
 fi
 pass "WU6A classes have no hooks, settings, or publication wiring"

--- a/tools/qa-article-pdf-persistence.sh
+++ b/tools/qa-article-pdf-persistence.sh
@@ -295,13 +295,13 @@ pass "real PDF persisted and invalid inputs create nothing"
 PERSISTER="$PLUGIN_DIR/includes/article-pdf/class-article-pdf-wordpress-persister.php"
 echo "== static guards (persistence only; no publication wiring) =="
 [[ -f "$PERSISTER" ]] || fail "Article_Pdf_WordPress_Persister file missing"
-if rg -q "add_action|add_filter" "$PERSISTER"; then
+if grep -Eq "add_action|add_filter" "$PERSISTER"; then
 	fail "persister must not register WordPress hooks"
 fi
-if rg -q "KEEP_EXISTING|GENERATE_REQUIRED|decide_pdf_action|decide_publication" "$PERSISTER"; then
+if grep -Eq "KEEP_EXISTING|GENERATE_REQUIRED|decide_pdf_action|decide_publication" "$PERSISTER"; then
 	fail "persister must not reimplement WU1/WU2 publication policy"
 fi
-if rg -q "wp_insert_post_data|rest_pre_insert|transition_post_status" "$PERSISTER"; then
+if grep -Eq "wp_insert_post_data|rest_pre_insert|transition_post_status" "$PERSISTER"; then
 	fail "persister must not wire publication"
 fi
 pass "persister source has no hooks or publication policy"

--- a/tools/qa-article-pdf-publication-enforcement.sh
+++ b/tools/qa-article-pdf-publication-enforcement.sh
@@ -765,7 +765,7 @@ ENFORCER="$PLUGIN_DIR/includes/article-pdf/class-article-pdf-publication-enforce
 echo "== static guards =="
 [[ -f "$SETTINGS" ]] || fail "settings class missing"
 [[ -f "$ENFORCER" ]] || fail "enforcer class missing"
-if rg -q "wp_insert_post_data|rest_pre_insert|transition_post_status" "$SETTINGS"; then
+if grep -Eq "wp_insert_post_data|rest_pre_insert|transition_post_status" "$SETTINGS"; then
 	fail "settings class must not own publication hooks"
 fi
 pass "settings/enforcer files present"

--- a/tools/qa-article-pdf-renderer.sh
+++ b/tools/qa-article-pdf-renderer.sh
@@ -47,13 +47,13 @@ trap cleanup EXIT
 echo "== static guards (no persistence in concrete renderer) =="
 RENDERER="$PLUGIN_DIR/includes/article-pdf/class-dompdf-article-pdf-renderer.php"
 [[ -f "$RENDERER" ]] || fail "Dompdf_Article_Pdf_Renderer file missing"
-if rg -q "media_handle_sideload|wp_insert_attachment|wp_generate_attachment_metadata|wp_update_attachment_metadata" "$RENDERER"; then
+if grep -Eq "media_handle_sideload|wp_insert_attachment|wp_generate_attachment_metadata|wp_update_attachment_metadata" "$RENDERER"; then
 	fail "renderer must not create or update attachments"
 fi
-if rg -q "update_post_meta|add_post_meta|delete_post_meta|wp_update_post|wp_insert_post" "$RENDERER"; then
+if grep -Eq "update_post_meta|add_post_meta|delete_post_meta|wp_update_post|wp_insert_post" "$RENDERER"; then
 	fail "renderer must not write posts or meta"
 fi
-if rg -q "add_action|add_filter" "$RENDERER"; then
+if grep -Eq "add_action|add_filter" "$RENDERER"; then
 	fail "renderer must not register WordPress hooks"
 fi
 pass "renderer source has no write/hook/persistence APIs"

--- a/tools/qa-editorial-bootstrap.sh
+++ b/tools/qa-editorial-bootstrap.sh
@@ -46,7 +46,7 @@ assert_contains() {
 	local file="$1"
 	local text="$2"
 
-	rg -F -q "$text" "$file" || fail "expected '$text' in $file"
+	grep -Fq "$text" "$file" || fail "expected '$text' in $file"
 }
 
 http_code() {
@@ -92,8 +92,8 @@ CORE_VERSION="$(cli core version)"
 PLUGIN_STATUS="$(cli plugin status revistalogos-core)"
 THEME_STATUS="$(cli theme status revistalogos)"
 [[ "$CORE_VERSION" == "7.1" ]] || fail "expected WordPress 7.1, got $CORE_VERSION"
-printf '%s' "$PLUGIN_STATUS" | rg -F -q "Status: Active" || fail "plugin not active"
-printf '%s' "$THEME_STATUS" | rg -F -q "Status: Active" || fail "theme not active"
+printf '%s' "$PLUGIN_STATUS" | grep -Fq "Status: Active" || fail "plugin not active"
+printf '%s' "$THEME_STATUS" | grep -Fq "Status: Active" || fail "theme not active"
 pass "WordPress 7.1, revistalogos theme and revistalogos-core plugin available"
 
 echo "== PHP syntax and recovery UI removal =="
@@ -144,8 +144,8 @@ AUTHOR_ID="$(cli post create \
 [[ "$AUTHOR_ID" =~ ^[0-9]+$ ]] || fail "could not create representative author"
 
 echo "== plan/dry-run performs no writes =="
-cli help revistalogos fixtures | rg -q bootstrap || fail "bootstrap subcommand missing"
-cli help revistalogos fixtures | rg -q plan || fail "plan subcommand missing"
+cli help revistalogos fixtures | grep -Eq bootstrap || fail "bootstrap subcommand missing"
+cli help revistalogos fixtures | grep -Eq plan || fail "plan subcommand missing"
 DB_BEFORE="$(relevant_db_hash)"
 cli revistalogos fixtures plan >"$TMP/plan.txt"
 cli revistalogos fixtures bootstrap >"$TMP/dry-run.txt"
@@ -182,7 +182,7 @@ EXPECTED_ORDER="editorial-vol-1-n-1,la-naturaleza-del-ser-en-la-filosofia-contem
 ARTICLE_ISSUE="$(cli post meta get "$ARTICLE1_ID" issue)"
 [[ "$ARTICLE_ISSUE" == "$ISSUE_ID" ]] || fail "article 1 is not linked to the Volume 1 issue"
 AUTHORS_META="$(cli eval "echo implode(',', array_map('strval', (array) get_post_meta( $ARTICLE1_ID, 'authors', true )));")"
-printf '%s' "$AUTHORS_META" | rg -q "^${AUTHOR_ID}$|^${AUTHOR_ID},|,${AUTHOR_ID}$|,${AUTHOR_ID}," || [[ "$AUTHORS_META" == "$AUTHOR_ID" ]] || fail "article 1 is not linked to Rafael (authors=$AUTHORS_META)"
+printf '%s' "$AUTHORS_META" | grep -Eq "^${AUTHOR_ID}$|^${AUTHOR_ID},|,${AUTHOR_ID}$|,${AUTHOR_ID}," || [[ "$AUTHORS_META" == "$AUTHOR_ID" ]] || fail "article 1 is not linked to Rafael (authors=$AUTHORS_META)"
 
 RAFAEL_BOOTSTRAP="$(cli post meta get "$AUTHOR_ID" _les_bootstrap || true)"
 RAFAEL_FIXTURE="$(cli post meta get "$AUTHOR_ID" _les_fixture || true)"
@@ -279,10 +279,10 @@ assert_contains "$TMP/teardown-plan.txt" "would delete issue ${ISSUE_ID}"
 assert_contains "$TMP/teardown-plan.txt" "would delete article ${ARTICLE2_ID}"
 assert_contains "$TMP/teardown-plan.txt" "adopted Volume 1 content; teardown refused"
 assert_contains "$TMP/teardown-plan.txt" "kept article ${ARTICLE1_ID} (adopted Volume 1 content; teardown refused)"
-if rg -q "would delete author ${AUTHOR_ID}" "$TMP/teardown-plan.txt"; then
+if grep -Eq "would delete author ${AUTHOR_ID}" "$TMP/teardown-plan.txt"; then
 	fail "teardown dry-run would delete Rafael"
 fi
-if rg -q "would delete post ${MANUAL_POST_ID}" "$TMP/teardown-plan.txt"; then
+if grep -Eq "would delete post ${MANUAL_POST_ID}" "$TMP/teardown-plan.txt"; then
 	fail "teardown dry-run would delete unrelated manual content"
 fi
 cli revistalogos fixtures teardown --kind=bootstrap --apply >"$TMP/teardown-apply.txt"
@@ -290,7 +290,7 @@ assert_contains "$TMP/teardown-apply.txt" "adopted Volume 1 content; teardown re
 assert_contains "$TMP/teardown-apply.txt" "deleted article ${EDITORIAL_ID}"
 assert_contains "$TMP/teardown-apply.txt" "deleted issue ${ISSUE_ID}"
 assert_contains "$TMP/teardown-apply.txt" "deleted article ${ARTICLE2_ID}"
-if rg -q "kept article ${EDITORIAL_ID}" "$TMP/teardown-apply.txt"; then
+if grep -Eq "kept article ${EDITORIAL_ID}" "$TMP/teardown-apply.txt"; then
 	fail "teardown classified unadopted editorial as adopted"
 fi
 STILL_ARTICLE="$(cli post get "$ARTICLE1_ID" --field=ID)"
@@ -317,7 +317,7 @@ STILL_AUTHOR2="$(cli post get "$AUTHOR_ID" --field=ID)"
 [[ "$STILL_AUTHOR2" == "$AUTHOR_ID" ]] || fail "second teardown deleted Rafael"
 STILL_MANUAL2="$(cli post get "$MANUAL_POST_ID" --field=ID)"
 [[ "$STILL_MANUAL2" == "$MANUAL_POST_ID" ]] || fail "second teardown deleted unrelated manual content"
-if rg -q "ERROR deleting" "$TMP/teardown-2.txt"; then
+if grep -Eq "ERROR deleting" "$TMP/teardown-2.txt"; then
 	fail "second teardown was not safe"
 fi
 pass "teardown removes only unadopted bootstrap objects; second run is safe"

--- a/tools/qa-editorial-bootstrap.sh
+++ b/tools/qa-editorial-bootstrap.sh
@@ -144,8 +144,12 @@ AUTHOR_ID="$(cli post create \
 [[ "$AUTHOR_ID" =~ ^[0-9]+$ ]] || fail "could not create representative author"
 
 echo "== plan/dry-run performs no writes =="
-cli help revistalogos fixtures | grep -Eq bootstrap || fail "bootstrap subcommand missing"
-cli help revistalogos fixtures | grep -Eq plan || fail "plan subcommand missing"
+# Dumped to a file instead of piped into `grep -q`: grep exits on the first
+# match, and under `pipefail` the SIGPIPE it sends back to the long WP-CLI
+# help output would surface as exit 141 — a spurious FAIL. One call, two greps.
+cli help revistalogos fixtures >"$TMP/fixtures-help.txt"
+grep -Eq "bootstrap" "$TMP/fixtures-help.txt" || fail "bootstrap subcommand missing"
+grep -Eq "plan" "$TMP/fixtures-help.txt" || fail "plan subcommand missing"
 DB_BEFORE="$(relevant_db_hash)"
 cli revistalogos fixtures plan >"$TMP/plan.txt"
 cli revistalogos fixtures bootstrap >"$TMP/dry-run.txt"

--- a/tools/qa-volume1-bootstrap-admin.sh
+++ b/tools/qa-volume1-bootstrap-admin.sh
@@ -133,7 +133,8 @@ VERSION_AFTER="$(cli eval 'echo get_option( Revistalogos_Core\Plugin::VERSION_OP
 [[ "$VERSION_AFTER" == "0.2.8" ]] || fail "upgrade did not record plugin version 0.2.8"
 pass "plugin upgrade does not alter Volume 1 objects, Rafael, or Pages"
 
-cli eval 'echo class_exists( "Revistalogos_Core\\Fixtures" ) ? "yes" : "no";' | grep -Eq '^yes$' || fail "Fixtures class must remain"
+FIXTURES_CLASS="$(cli eval 'echo class_exists( "Revistalogos_Core\\Fixtures" ) ? "yes" : "no";')"
+[[ "$FIXTURES_CLASS" == "yes" ]] || fail "Fixtures class must remain (got '$FIXTURES_CLASS')"
 pass "Fixtures domain still available"
 
 cli revistalogos fixtures verify >"$TMP/verify.txt"

--- a/tools/qa-volume1-bootstrap-admin.sh
+++ b/tools/qa-volume1-bootstrap-admin.sh
@@ -41,7 +41,7 @@ trap cleanup EXIT
 if [[ -f "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures/class-bootstrap-admin.php" ]]; then
 	fail "class-bootstrap-admin.php must be deleted"
 fi
-if rg -q "Bootstrap_Admin" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php"; then
+if grep -Eq "Bootstrap_Admin" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php"; then
 	fail "Plugin must not register Bootstrap_Admin"
 fi
 pass "Bootstrap_Admin source and wiring absent"
@@ -76,7 +76,7 @@ ABSENT="$(cli eval 'echo class_exists( "Revistalogos_Core\\Bootstrap_Admin" ) ? 
 pass "Bootstrap_Admin class absent at runtime"
 
 cli eval 'echo menu_page_url( "revistalogos-volume-1-bootstrap", false );' >"$TMP/menu.txt"
-if rg -q "revistalogos-volume-1-bootstrap" "$TMP/menu.txt"; then
+if grep -Eq "revistalogos-volume-1-bootstrap" "$TMP/menu.txt"; then
 	fail "Tools bootstrap page must not be registered"
 fi
 pass "Tools Volume 1 bootstrap menu absent"
@@ -97,7 +97,7 @@ cli post create \
 	--porcelain >/dev/null
 
 cli revistalogos fixtures plan >"$TMP/plan.txt"
-rg -q "volume-1" "$TMP/plan.txt" || fail "fixtures plan must still work"
+grep -Eq "volume-1" "$TMP/plan.txt" || fail "fixtures plan must still work"
 pass "Fixtures domain plan still available"
 
 cli revistalogos fixtures bootstrap --apply >"$TMP/apply.txt"
@@ -133,15 +133,15 @@ VERSION_AFTER="$(cli eval 'echo get_option( Revistalogos_Core\Plugin::VERSION_OP
 [[ "$VERSION_AFTER" == "0.2.8" ]] || fail "upgrade did not record plugin version 0.2.8"
 pass "plugin upgrade does not alter Volume 1 objects, Rafael, or Pages"
 
-cli eval 'echo class_exists( "Revistalogos_Core\\Fixtures" ) ? "yes" : "no";' | rg -q '^yes$' || fail "Fixtures class must remain"
+cli eval 'echo class_exists( "Revistalogos_Core\\Fixtures" ) ? "yes" : "no";' | grep -Eq '^yes$' || fail "Fixtures class must remain"
 pass "Fixtures domain still available"
 
 cli revistalogos fixtures verify >"$TMP/verify.txt"
 pass "fixtures verify still available via CLI"
 
 cli revistalogos fixtures teardown --help >"$TMP/teardown-help.txt"
-rg -qi "teardown" "$TMP/teardown-help.txt" || fail "teardown CLI must remain"
-if rg -q "add_management_page|add_submenu_page" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures" 2>/dev/null; then
+grep -Eqi "teardown" "$TMP/teardown-help.txt" || fail "teardown CLI must remain"
+if grep -REq "add_management_page|add_submenu_page" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures" 2>/dev/null; then
 	fail "fixtures includes must not register an admin Tools page"
 fi
 pass "teardown remains CLI/dev only"

--- a/tools/qa-volume1-bootstrap-admin.sh
+++ b/tools/qa-volume1-bootstrap-admin.sh
@@ -141,9 +141,20 @@ pass "fixtures verify still available via CLI"
 
 cli revistalogos fixtures teardown --help >"$TMP/teardown-help.txt"
 grep -Eqi "teardown" "$TMP/teardown-help.txt" || fail "teardown CLI must remain"
-if grep -REq "add_management_page|add_submenu_page" "$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures" 2>/dev/null; then
-	fail "fixtures includes must not register an admin Tools page"
-fi
+
+# Recursive guard over a directory: treat grep's exit codes explicitly
+# (0 = match, 1 = no match, >=2 = grep error) so a real failure — e.g. the
+# path is gone or -R is unsupported — cannot masquerade as "no admin page",
+# which is exactly the silent-pass this harness change is meant to remove.
+FIXTURES_INCLUDES="$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures"
+[[ -d "$FIXTURES_INCLUDES" ]] || fail "fixtures includes directory missing: $FIXTURES_INCLUDES"
+GREP_RC=0
+grep -REq "add_management_page|add_submenu_page" "$FIXTURES_INCLUDES" || GREP_RC=$?
+case "$GREP_RC" in
+	0) fail "fixtures includes must not register an admin Tools page" ;;
+	1) ;;
+	*) fail "grep failed (exit $GREP_RC) scanning $FIXTURES_INCLUDES" ;;
+esac
 pass "teardown remains CLI/dev only"
 
 echo "== HTTP routes =="

--- a/tools/qa-volume1-bootstrap-admin.sh
+++ b/tools/qa-volume1-bootstrap-admin.sh
@@ -142,14 +142,22 @@ pass "fixtures verify still available via CLI"
 cli revistalogos fixtures teardown --help >"$TMP/teardown-help.txt"
 grep -Eqi "teardown" "$TMP/teardown-help.txt" || fail "teardown CLI must remain"
 
-# Recursive guard over a directory: treat grep's exit codes explicitly
-# (0 = match, 1 = no match, >=2 = grep error) so a real failure — e.g. the
-# path is gone or -R is unsupported — cannot masquerade as "no admin page",
+# Guard over a directory tree. The file list comes from `find` (POSIX) rather
+# than `grep -R`, which is a GNU/BSD extension. grep's exit code is then read
+# explicitly (0 = match, 1 = no match, >=2 = grep error) so a real failure —
+# a missing path, an unreadable file — cannot masquerade as "no admin page",
 # which is exactly the silent-pass this harness change is meant to remove.
 FIXTURES_INCLUDES="$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures"
 [[ -d "$FIXTURES_INCLUDES" ]] || fail "fixtures includes directory missing: $FIXTURES_INCLUDES"
+
+FIXTURES_FILES=()
+while IFS= read -r fixture_file; do
+	FIXTURES_FILES+=("$fixture_file")
+done < <(find "$FIXTURES_INCLUDES" -type f -name '*.php')
+[[ "${#FIXTURES_FILES[@]}" -gt 0 ]] || fail "no PHP files found under $FIXTURES_INCLUDES"
+
 GREP_RC=0
-grep -REq "add_management_page|add_submenu_page" "$FIXTURES_INCLUDES" || GREP_RC=$?
+grep -Eq "add_management_page|add_submenu_page" "${FIXTURES_FILES[@]}" || GREP_RC=$?
 case "$GREP_RC" in
 	0) fail "fixtures includes must not register an admin Tools page" ;;
 	1) ;;

--- a/tools/qa-volume1-bootstrap-admin.sh
+++ b/tools/qa-volume1-bootstrap-admin.sh
@@ -151,10 +151,19 @@ grep -Eqi "teardown" "$TMP/teardown-help.txt" || fail "teardown CLI must remain"
 FIXTURES_INCLUDES="$ROOT/wordpress/wp-content/plugins/revistalogos-core/includes/fixtures"
 [[ -d "$FIXTURES_INCLUDES" ]] || fail "fixtures includes directory missing: $FIXTURES_INCLUDES"
 
+# The list is materialised to a file rather than read from a process
+# substitution: there, find's exit code is unreachable, so a partial listing
+# (an unreadable subdirectory, say) would scan fewer files and still report
+# "no admin page" — the same silent pass in a new place.
+FIXTURES_LIST="$TMP/fixtures-php-files.txt"
+FIND_RC=0
+find "$FIXTURES_INCLUDES" -type f -name '*.php' >"$FIXTURES_LIST" || FIND_RC=$?
+[[ "$FIND_RC" -eq 0 ]] || fail "find failed (exit $FIND_RC) listing PHP files under $FIXTURES_INCLUDES"
+
 FIXTURES_FILES=()
 while IFS= read -r fixture_file; do
 	FIXTURES_FILES+=("$fixture_file")
-done < <(find "$FIXTURES_INCLUDES" -type f -name '*.php')
+done <"$FIXTURES_LIST"
 [[ "${#FIXTURES_FILES[@]}" -gt 0 ]] || fail "no PHP files found under $FIXTURES_INCLUDES"
 
 GREP_RC=0


### PR DESCRIPTION
## Problema

En una máquina sin `rg`, `if rg -q ...` imprime «rg: command not found» (exit 127) y el guard estático **pasa en silencio** como si no hubiera coincidencias. Visto en ejecución local el 2026-08-28 en `tools/qa-article-pdf-composition.sh`. Afectaba a los 8 harnesses que usaban ripgrep (56 llamadas).

## Arreglo

Se elimina la dependencia de ripgrep: los archivos inspeccionados son pequeños y `grep` está garantizado en cualquier host POSIX, así que no hay doble camino rg/grep que mantener.

- `rg -q` → `grep -Eq` · `rg -F -q` → `grep -Fq` · `rg -qi` → `grep -Eqi` · `rg -o` → `grep -Eo`
- Objetivo directorio (`includes/fixtures` en `qa-volume1-bootstrap-admin.sh`) → `grep -REq` (un `grep` sin `-R` sobre un directorio habría fallado igual de silencioso dentro del `if`)
- `\s` → `[[:space:]]` en los dos patrones CSS (compatible con BSD grep y GNU grep)

## Verificación

- `bash -n` en los 8 scripts.
- Veredicto esperado de **cada** expresión convertida comprobado contra los archivos reales del repo en un host sin `rg` (BSD grep de macOS): positivos y negativos coinciden, incluidas las extracciones `grep -Eo | cut` y los greps por pipe.
- Harnesses completos en Docker aislado: `tools/qa-article-pdf-composition.sh` y `tools/qa-article-editorial-ux.sh` — **PASS de punta a punta**, y la sección «static guards» ahora se ejecuta de verdad.

## Nota de merge

`feat/article-pdf-editorial-design` (#20) toca las mismas líneas del guard de `qa-article-pdf-composition.sh` (añade `$TEMPLATE`, aún con `rg`). Sugerencia: **mergear #20 primero** y aviso para rebasar esta rama (conflicto trivial de 3 líneas, y así el guard nuevo de #20 también queda en `grep`). Esta rama no referencia `$TEMPLATE` a propósito: ese archivo no existe todavía en `main`.

Cierra el hallazgo registrado en la sesión del diseño editorial del PDF (issue #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)