### PR TITLE
fix(deps): elevar picomatch a 2.3.2 (GHSA-3v7f-55p6-f55p)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1105,9 +1105,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Problema

Única alerta de Dependabot **abierta** en `main`: [#4](https://github.com/refo44/demo-revistalogos/security/dependabot/4) — [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p) / CVE-2026-33672, severidad *medium*. Method injection en clases de caracteres POSIX de `picomatch` que produce un glob matching incorrecto.

De las 18 alertas del repositorio, el resto ya estaban `fixed` o `auto_dismissed`. La alerta [#3](https://github.com/refo44/demo-revistalogos/security/dependabot/3) (GHSA-c2c7-rcm5-vvqj, ReDoS, *high*) afecta al mismo rango `< 2.3.2` y quedó auto-dismissed por ser dev-only: este bump también la cubre.

## Arreglo

`picomatch` es una dependencia **transitiva de desarrollo**: `stylelint → micromatch → picomatch ^2.3.1`. Como `^2.3.1` ya admite 2.3.2, basta actualizar el lockfile (`npm update picomatch --package-lock-only`); `package.json` no se toca.

Diff: 3 líneas en `package-lock.json` (`version`, `resolved`, `integrity`).

## Verificación

- `npm ci` → rc=0, `picomatch` 2.3.2 instalado.
- `npm audit` → **0 vulnerabilities**.
- `npm run lint:css` → salida **idéntica byte a byte** antes y después del bump (mismos 2 ficheros analizados por los globs; la única diferencia era el PID en una línea de warning). El cambio es neutro en comportamiento.

Ningún workflow de CI ejecuta npm, así que este lockfile solo afecta al `lint:css` local.

## Procedencia

Este commit estaba inicialmente en #21 a petición del owner. Copilot recomendó separarlo por no estar relacionado con el objetivo de aquel PR, y se ha movido aquí; #21 vuelve a contener solo los cambios de los harnesses QA.

## Nota aparte (no se aborda aquí)

`npm run lint:css` **ya falla en `main`**, antes y después de este cambio: 16 errores de stylelint (`color-hex-length`, `value-keyword-case`) en `static/assets/css/tokens.css` y `wordpress/wp-content/themes/revistalogos/assets/css/tokens.css`, todos autocorregibles con `--fix`. Condición preexistente y sin relación con esta vulnerabilidad; probablemente por reglas más estrictas en `stylelint-config-standard` 40. Merece su propia rama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)