### PR TITLE
chore(lint): corregir los globs de overrides de stylelint

### DIFF
--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -21,15 +21,23 @@ export default {
       }
     ]
   },
+  // Override globs are resolved relative to this config file, so they need a
+  // leading `**/` to reach the two CSS trees (`static/assets/css/**` and
+  // `wordpress/wp-content/themes/revistalogos/assets/css/**`). Without it
+  // neither override matched anything: `color-no-hex` never ran, and
+  // tokens.css lost its intended exemption.
   overrides: [
     {
-      files: ["assets/css/**/*.css"],
+      files: ["**/assets/css/**/*.css"],
       rules: {
         "color-no-hex": true
       }
     },
     {
-      files: ["assets/css/tokens.css"],
+      // tokens.css is where the raw palette and the system font stacks are
+      // declared, so it keeps its hex literals and the vendor casing of font
+      // names (`BlinkMacSystemFont`, `Georgia`, …). Listed last so it wins.
+      files: ["**/assets/css/tokens.css"],
       rules: {
         "color-hex-length": null,
         "color-no-hex": null,

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -21,14 +21,19 @@ export default {
       }
     ]
   },
-  // Override globs are resolved relative to this config file, so they need a
-  // leading `**/` to reach the two CSS trees (`static/assets/css/**` and
-  // `wordpress/wp-content/themes/revistalogos/assets/css/**`). Without it
-  // neither override matched anything: `color-no-hex` never ran, and
-  // tokens.css lost its intended exemption.
+  // Override globs are resolved relative to this config file. A bare
+  // `assets/css/**` matched nothing, so `color-no-hex` never ran and
+  // tokens.css lost its intended exemption. The paths are spelled out rather
+  // than reached with `**/`, which would also pull in unrelated trees such as
+  // `wordpress/wp-content/plugins/revistalogos-core/assets/css/` — admin CSS
+  // that legitimately uses hex and is outside the design-token system. These
+  // two globs mirror the `lint:css` script exactly.
   overrides: [
     {
-      files: ["**/assets/css/**/*.css"],
+      files: [
+        "static/assets/css/**/*.css",
+        "wordpress/wp-content/themes/revistalogos/assets/css/**/*.css"
+      ],
       rules: {
         "color-no-hex": true
       }
@@ -37,7 +42,10 @@ export default {
       // tokens.css is where the raw palette and the system font stacks are
       // declared, so it keeps its hex literals and the vendor casing of font
       // names (`BlinkMacSystemFont`, `Georgia`, …). Listed last so it wins.
-      files: ["**/assets/css/tokens.css"],
+      files: [
+        "static/assets/css/tokens.css",
+        "wordpress/wp-content/themes/revistalogos/assets/css/tokens.css"
+      ],
       rules: {
         "color-hex-length": null,
         "color-no-hex": null,


### PR DESCRIPTION
## Problema

`npm run lint:css` **falla en `main`** con 16 errores, 8 en cada `tokens.css`:

```
static/assets/css/tokens.css
  23:20  ✖  Expected "#ffffff" to be "#fff"                           color-hex-length
  37:41  ✖  Expected "BlinkMacSystemFont" to be "blinkmacsystemfont"  value-keyword-case
  37:73  ✖  Expected "Roboto" to be "roboto"                          value-keyword-case
  …
```

La causa **no es el CSS, es la configuración**. Los globs de `overrides` en `stylelint.config.mjs` se resuelven relativos al fichero de config, y ninguno de los dos casaba con las rutas reales (`static/assets/css/**` y `wordpress/wp-content/themes/revistalogos/assets/css/**`):

```js
files: ["assets/css/**/*.css"]   // no casa con nada
files: ["assets/css/tokens.css"] // no casa con nada
```

Dos consecuencias, y la segunda es la que importa de verdad:

1. **`tokens.css` perdía su exención.** El override le anula `color-hex-length`, `color-no-hex` y `value-keyword-case` a propósito; al no aplicarse, saltaban los 16 errores.
2. **`color-no-hex` no se aplicaba a ningún fichero.** La política «solo `tokens.css` declara literales hex» estaba **inerte**. El código sí la cumple —0 hex en los otros 20 CSS— pero nada lo impedía.

## Arreglo

Los globs de ambos overrides pasan a escribirse con **rutas explícitas**, reflejando exactamente el script `lint:css`:

```js
files: [
  "static/assets/css/**/*.css",
  "wordpress/wp-content/themes/revistalogos/assets/css/**/*.css"
]
```

<details>
<summary>Por qué rutas explícitas y no un prefijo <code>**/</code></summary>

La primera versión de este PR resolvía el problema prefijando `**/` a los globs existentes. Funcionaba para los 16 errores, pero [Copilot señaló](https://github.com/refo44/demo-revistalogos/pull/23#discussion_r3885443831) que `**/assets/css/**/*.css` alcanza más de lo previsto, y no era teórico: también casa con `wordpress/wp-content/plugins/revistalogos-core/assets/css/admin-meta.css`, que usa 4 colores hex. Reproducido con un config temporal que replica aquel glob:

```
10:20  ✖  Unexpected hex color "#c3c4c7"  color-no-hex
26:27  ✖  Unexpected hex color "#dcdcde"  color-no-hex
27:14  ✖  Unexpected hex color "#fff"     color-no-hex
33:14  ✖  Unexpected hex color "#f0f0f1"  color-no-hex
```

Son los grises estándar del admin de WordPress: legítimos y ajenos al sistema de tokens. Quedaba latente solo porque `lint:css` no cubre esa ruta, pero habría saltado en cuanto alguien la incluyera. De ahí las rutas explícitas, que además hacen imposible que un `assets/css` futuro herede la regla por accidente.

</details>

**No se toca ningún CSS.** Los literales hex y el casing de las familias tipográficas del sistema son intencionados. Ejecutar `--fix`, que era la salida evidente, habría minusculado nombres propios de fuentes (`BlinkMacSystemFont` → `blinkmacsystemfont`, `Georgia` → `georgia`) y alterado la base visual congelada de la Fase 2, para «arreglar» algo que nunca debió reportarse.

## Verificación

- `npm run lint:css` → **rc=0**.
- **Prueba negativa**, la que confirma que el arreglo hace algo real: se inyecta `color: #abcdef` en `components.css`.
  - Config **nueva** → `593:20 ✖ Unexpected hex color "#abcdef" color-no-hex`, rc=2. ✅
  - Config **original** → no se detecta. ❌

  Es decir, `color-no-hex` pasa de muerta a activa, y ahora sí protege la política de tokens.
- **Acotación**: `admin-meta.css` del plugin **no** recibe `color-no-hex` con la config final, mientras que con el glob `**/` intermedio recibía los 4 errores de arriba.

## Contexto

Detectado al verificar el bump de `picomatch` (#22); condición preexistente y sin relación con aquella vulnerabilidad, por eso va en rama aparte. Ningún workflow de CI ejecuta npm, así que esto no bloqueaba nada — pero significaba que `lint:css` estaba roto en local para cualquiera que lo ejecutara, y que una de sus reglas no protegía nada.

Rama rebasada sobre `main` tras el merge de #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
