### PR TITLE
chore(ci): scope SonarQube Cloud automatic analysis

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,7 @@ Paths: plugin `wordpress/wp-content/plugins/revistalogos-core/`, theme `wordpres
 - Labels: `praise`, `nitpick`, `suggestion`, `issue`, `todo`, `question`, `thought`, `chore`, `note`, `typo`. At most one extra decoration (`security`, `test`, `if-minor`).
 - Leave a **Comment** review. Merge lock is CI `PHP lint, Composer audit, and unit (PHP 8.3)`. Approvals = 0 (ADR 0019).
 - KISS/YAGNI. Do not suggest `develop`, GitFlow, CODEOWNERS, commitlint, required reviews, extra CI runners, PHPCS/PHPStan/Psalm, Playwright, the official WP test suite, DI containers, or new Composer/plugin dependencies without an ADR.
+- Do not suggest `sonar-project.properties`, a Sonar CI scanner while Automatic Analysis is ON, or treating Quality Gate 0.0% coverage as a missing PHPUnit suite. Scope is `.sonarcloud.properties`. Does not close D12b.
 - Do not suggest changing deploy (manual `workflow_dispatch` from an annotated `vX.Y.Z` tag, ADR 0009 + ADR 0020) or hosting PHP. Merge to `main` is not a production deploy. Pages auto-publish after merge to `main` is deliberate. Do not suggest keeping merged feature branches; GitHub deletes PR head branches on merge.
 
 ## Scope — do not demand

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -29,8 +29,10 @@ behaviour and a running app is in scope.
 
 `develop`, GitFlow, CODEOWNERS, commitlint, required reviews, extra CI runners,
 PHPCS/PHPStan/Psalm, Playwright, the official WP test suite, DI containers, or
-new Composer/plugin dependencies without an ADR. Do not change deploy
-(`workflow_dispatch` from an annotated `vX.Y.Z` tag, ADR 0009 + ADR 0020)
+new Composer/plugin dependencies without an ADR. Do not suggest
+`sonar-project.properties`, a Sonar CI scanner while Automatic Analysis is
+ON, or treating Quality Gate 0.0% coverage as a missing test suite. Do not
+change deploy (`workflow_dispatch` from an annotated `vX.Y.Z` tag, ADR 0009 + ADR 0020)
 or hosting PHP. Merge to `main` is not a production deploy. Pages
 auto-publish on `main` is deliberate. Do not suggest keeping merged
 feature branches; GitHub deletes the PR head branch on merge.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,8 @@
 # no secrets. Does not close D12b (security-audit automation). WordPress
 # integration remains isolated tools/qa-*.sh until a PHPUnit integration
 # suite is added. Root composer audit covers test tooling. Plugin
-# composer audit covers runtime Dompdf (ADR 0017 WU4).
+# composer audit covers runtime Dompdf (ADR 0017 WU4). Does not run
+# SonarScanner: Automatic Analysis is ON (.sonarcloud.properties).
 name: Tests
 
 on:

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,26 @@
+# SonarQube Cloud Automatic Analysis (GitHub App).
+#
+# This is not sonar-project.properties. While Automatic Analysis is ON,
+# SonarQube Cloud ignores sonar-project.properties. Scope lives here
+# and takes effect after the file is on the default branch (main).
+#
+# Do not add a CI scanner while Automatic Analysis is ON: duplicate
+# analyses fail the GitHub check. Coverage is not supported under
+# Automatic Analysis; 0.0% Coverage on New Code is expected, not a
+# missing test suite. The default Quality Gate skips the coverage
+# condition when coverage is not computed. That is not a PHPUnit
+# coverage gate (ADR 0018 / docs/23: do not gate on coverage %).
+#
+# Project key (SonarQube Cloud): refo44_demo-revistalogos
+# Docs: https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/automatic-analysis
+#
+# First-party production code only. Frozen static/ maquette is
+# excluded so copy-paste detection does not flag the intentional
+# CSS/JS duplication with the WordPress theme (ADR 0001 / 0003).
+# Plugin vendor/ is gitignored; listed here in case it appears in a
+# working tree. Automatic Analysis does not allow glob wildcards.
+
+sonar.sources=wordpress/wp-content/plugins/revistalogos-core,wordpress/wp-content/themes/revistalogos
+sonar.tests=tests
+sonar.exclusions=wordpress/wp-content/plugins/revistalogos-core/vendor,wordpress/wp-content/plugins/revistalogos-core/resources
+sonar.sourceEncoding=UTF-8

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -18,9 +18,16 @@
 # excluded so copy-paste detection does not flag the intentional
 # CSS/JS duplication with the WordPress theme (ADR 0001 / 0003).
 # Plugin vendor/ is gitignored; listed here in case it appears in a
-# working tree. Automatic Analysis does not allow glob wildcards.
+# working tree.
+#
+# Wildcard patterns are not allowed anywhere in .sonarcloud.properties,
+# not only in sonar.sources: the docs state it for the whole supported
+# settings list. So exclusions are plain paths, and the only analyzable
+# file under resources/ (the rest are PDF/JPG) is also listed by exact
+# path, which does not depend on directory-prefix matching. Verify the
+# effective scope in SonarQube Cloud after this lands on main.
 
 sonar.sources=wordpress/wp-content/plugins/revistalogos-core,wordpress/wp-content/themes/revistalogos
 sonar.tests=tests
-sonar.exclusions=wordpress/wp-content/plugins/revistalogos-core/vendor,wordpress/wp-content/plugins/revistalogos-core/resources
+sonar.exclusions=wordpress/wp-content/plugins/revistalogos-core/vendor,wordpress/wp-content/plugins/revistalogos-core/resources,wordpress/wp-content/plugins/revistalogos-core/resources/content-payload.json
 sonar.sourceEncoding=UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+### Added
+- SonarQube Cloud Automatic Analysis scope: `.sonarcloud.properties`
+  (plugin `revistalogos-core` + theme `revistalogos`; `tests/` as tests).
+  Not `sonar-project.properties` (ignored while Automatic Analysis is ON).
+  Coverage is not imported; 0.0% on the Quality Gate comment is expected.
+  Does not close D12b.
+
 ## [0.3.0] — 2026-08-29
 
 Primer release etiquetado desde `v0.2.0`. Recoge la generación automática

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,12 @@ required, not shared via Git, not a substitute for the files above.
   `composer.json` is test-only. Composer audit does not scan WordPress,
   npm, or hosting. Dependabot may open weekly Composer and GitHub Actions
   PRs; they are not auto-merged. Review them after CI. Do not treat a
-  PHPUnit major as an automatic policy change.
+  PHPUnit major as an automatic policy change. SonarQube Cloud is GitHub
+  App **Automatic Analysis** (project `refo44_demo-revistalogos`). Scope
+  lives in `.sonarcloud.properties`. Do not add `sonar-project.properties`
+  or a CI scanner while Automatic Analysis is ON (duplicate analyses
+  fail). Do not treat Quality Gate 0.0% coverage as a missing PHPUnit
+  suite. Does not close D12b.
 
 ## Working style
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ revistalogos/
 ├── tools/                           → Payload generator, PHPUnit wrapper, qa-*.sh
 ├── docs/                            → Documentación numerada, ADRs, harness Fase 3
 ├── content-source/                  → Fuente canónica (no versionada)
-└── .github/workflows/               → deploy-wordpress.yml (producción WP, manual),
+├── .sonarcloud.properties           → Alcance SonarQube Cloud (Automatic Analysis)
+└── .github/workflows/               → test.yml (lint/audit/units),
+                                       deploy-wordpress.yml (producción WP, manual),
                                        pages.yml (espejo estático beta, automático)
 ```
 
@@ -77,7 +79,10 @@ and its transitives only — not WordPress, npm, or hosting). Units:
 the `./tools/*.sh` wrappers and `composer:2` for audit. WordPress workflows
 remain isolated `tools/qa-*.sh`. Root Composer is **dev/test only**. Dependabot: weekly Composer + GitHub
 Actions PRs, no auto-merge; CI + owner review. `composer audit --locked`
-stays the lockfile advisory check.
+stays the lockfile advisory check. SonarQube Cloud is **Automatic Analysis**
+(GitHub App, project `refo44_demo-revistalogos`); scope is
+`.sonarcloud.properties` (plugin + theme). Not a PHPUnit coverage gate
+and does not close D12b. See `docs/23-testing-foundation.md`.
 
 ## Características de diseño
 

--- a/docs/00-order-documents.md
+++ b/docs/00-order-documents.md
@@ -29,7 +29,7 @@ Todos los documentos de arquitectura del sitio se redactan en español. Los tér
 | **20** | Principios de maquetación | Ancho de lectura, ritmo vertical, uso del espacio en blanco, relación tipografía/imagen. Cierra el sistema visual antes de escribir HTML. |
 | **21** | Diagrama de recorrido del usuario | Diagrama Mermaid de flujos del visitante. Validación visual de 10-user-journey. |
 | **22** | Identificadores académicos | DOI (Crossref) y ORCID: validación, flujo de depósito, costes. Depende del modelo de contenido (03) y del orden de implementación (17); documenta ADR 0013. |
-| **23** | Pruebas | Testing Foundation (PHPUnit, `php -l`, Gherkin, TDD). No reordena 18–22. |
+| **23** | Pruebas | Testing Foundation (PHPUnit, `php -l`, Gherkin, TDD, alcance SonarQube Cloud). No reordena 18–22. |
 | **24** | Oficio de pruebas | Cómo escribir un test (sociable-first, BDD, AAA, dobles). Depende de 23. Siguiente número libre. |
 
 ---
@@ -127,5 +127,5 @@ Estos principios aplican independientemente del tipo de sitio (comunidad, autor,
 
 ---
 
-**Versión:** 1.1  
+**Versión:** 1.2  
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/23-testing-foundation.md
+++ b/docs/23-testing-foundation.md
@@ -112,7 +112,7 @@ con `--no-dev` y lo sube.
 ## PHPUnit y Composer
 
 - Runner: **PHPUnit 9.6** (`phpunit/phpunit`, `require-dev`).
-- Sintaxis: nativo `php -l` vía `tools/php-lint.sh` / `composer lint:php`. Sin PHPStan, Psalm ni PHPCS.
+- Sintaxis: nativo `php -l` vía `tools/php-lint.sh` / `composer lint:php`. Sin PHPStan, Psalm ni PHPCS. SonarQube Cloud es Automatic Analysis (`.sonarcloud.properties`), no sustituye esos linters ni cierra D12b.
 - `composer test` = lint PHP + `composer audit --locked` + suite unitaria.
   No ejecuta `tools/qa-*.sh`.
 - Composer de raíz: **solo** tooling de test. El plugin carga su
@@ -324,7 +324,8 @@ toquen ese código.
 (dev/test). CI también audita el lock runtime del plugin (Dompdf).
 No escanea WordPress Core, plugins/themes de terceros, npm ni el hosting.
 No es un sustituto de revisión de seguridad del producto, no cierra D12b
-y no aplica parches. Dependabot (Composer + GitHub Actions, semanal)
+y no aplica parches. SonarQube Cloud Automatic Analysis (issues en plugin y
+theme) tampoco sustituye esa revisión ni cierra D12b. Dependabot (Composer + GitHub Actions, semanal)
 abre PRs; no sustituye el audit ni se auto-mergea. Un major de PHPUnit
 que suba el baseline de PHP no se acepta por inercia.
 

--- a/docs/23-testing-foundation.md
+++ b/docs/23-testing-foundation.md
@@ -298,6 +298,16 @@ Sin environment de producción, sin secretos FTPS, sin deploy. No cierra
 D12b. Sin matriz PHP/WP. La integración en CI es el siguiente incremento
 (harness o PHPUnit/WP), no este.
 
+SonarQube Cloud está conectado por GitHub App (**Automatic Analysis**,
+proyecto `refo44_demo-revistalogos`). El alcance vive en
+`.sonarcloud.properties` (plugin + theme; `tests/` como tests). No usar
+`sonar-project.properties` mientras Automatic Analysis esté ON: Sonar lo
+ignora. Automatic Analysis **no** importa cobertura PHPUnit; el 0.0 %
+en el comentario del Quality Gate es esperado y **no** es un gate de
+cobertura (ADR 0018). Un scanner en `test.yml` exigiría apagar Automatic
+Analysis en Administration → Analysis Method y un `SONAR_TOKEN`; no se
+añade aquí y no cierra D12b.
+
 ## Accesibilidad
 
 Checks automáticos (axe, Playwright) son útiles y **insuficientes**. No
@@ -345,5 +355,5 @@ matriz de versiones) solo con necesidad arquitectónica demostrada. ADR 0017
 work unit 1 ya tiene la política pura; no adelantar `PdfGenerator` ni
 librerías PDF hasta la unidad de renderer.
 
-**Versión:** 1.1
+**Versión:** 1.2
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/24-project-testing-standard.md
+++ b/docs/24-project-testing-standard.md
@@ -486,7 +486,7 @@ agotar la máquina apilando QA Docker.
 | **Nivel 1 (gate por defecto)** | `composer test` o `./tools/run-phpunit.sh` — lint, audit del lockfile, suite unitaria completa. La suite es pequeña; correrla entera. |
 | **Nivel 2/3** | El `tools/qa-*.sh` **relevante** cuando cambió integración WordPress. Un harness a la vez. Cada uno debe hacer `down -v` y salir. |
 | **Prohibido** | BD de producción; volúmenes primarios en tests nuevos que mutan; todos los harnesses «por si acaso» en un cambio solo unitario; instalar runners extra por teatro de cobertura |
-| **CI** | `.github/workflows/test.yml` es lint + audit Composer (raíz y plugin) + `composer test:unit`. No corre `qa-*.sh`. No exigir Docker QA en un PR solo de docs o solo unitario. |
+| **CI** | `.github/workflows/test.yml` es lint + audit Composer (raíz y plugin) + `composer test:unit`. No corre `qa-*.sh`. No exigir Docker QA en un PR solo de docs o solo unitario. SonarQube Cloud es Automatic Analysis (`.sonarcloud.properties`); no es un gate de cobertura ni un paso de `test.yml`. |
 
 Portátil sin PHP nativo: `./tools/php-lint.sh` y `./tools/run-phpunit.sh`
 (ADR 0014).
@@ -654,7 +654,8 @@ No testear:
 - One-liners triviales
 - Comportamiento puro del lenguaje PHP
 - Layout CSS y whitespace
-- Porcentaje de cobertura
+- Porcentaje de cobertura (el 0.0 % del Quality Gate de SonarQube Cloud
+  bajo Automatic Analysis no es un fallo de la suite; `docs/23`)
 - Validación de identificadores de Fase 4 (DOI/ORCID/ISSN) — campos inertes
   (ADR 0013)
 - Activar la exigencia de PDF al publicar como efecto de un deploy
@@ -682,5 +683,5 @@ composer test:unit
 
 ---
 
-**Versión:** 1.0
+**Versión:** 1.1
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ Documentación para el sitio web de la revista académica. CENFISS (Centro de Fi
 | 20 | layout-principles | Ancho de lectura, ritmo, responsive |
 | 21 | user-journey-diagram | Diagrama Mermaid de recorridos |
 | 22 | identificadores-academicos-doi-orcid | Registro DOI (Crossref) y reconocimiento de autoría (ORCID): validación, flujo de depósito, costes |
-| 23 | testing-foundation | Testing Foundation: PHPUnit, taxonomía, Gherkin, TDD, harnesses QA, CI |
+| 23 | testing-foundation | Testing Foundation: PHPUnit, taxonomía, Gherkin, TDD, harnesses QA, CI, alcance SonarQube Cloud |
 | 24 | project-testing-standard | Oficio de pruebas: sociable-first, BDD, AAA, dobles manuscritos, qué no testear |
 
 Harness de Fase 3 (fuera de la numeración): `fase3-execution-state.md` (reanudación), `fase3-validation-matrix.md` (QA), `migracion-static-wordpress.md` (ledger ADR 0001–0003), `operations/` ([runbook de producción](operations/wordpress-manual-deployment.md), [snapshot](operations/produccion-wordpress.md), Docker, plugins de terceros). ADR de pruebas: [0018](adr/0018-testing-foundation.md). Oficio: [24-project-testing-standard](24-project-testing-standard.md).
@@ -76,5 +76,5 @@ Ningún documento puede depender de uno con número mayor. Ver `00-order-documen
 
 ---
 
-**Versión:** 1.5
+**Versión:** 1.6
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/adr/0018-testing-foundation.md
+++ b/docs/adr/0018-testing-foundation.md
@@ -89,8 +89,17 @@ test vive en `docs/24-project-testing-standard.md`. Complementa `docs/23`
 (taxonomía, CI, comandos). No añade runners ni cambia PHPUnit 9.6, Gherkin
 sin Behat, ni la exclusión de Brain Monkey / Mockery / Pest.
 
+Nota factual 2026-08-28 (no cambia §1–§6): SonarQube Cloud está
+conectado por GitHub App (**Automatic Analysis**, proyecto
+`refo44_demo-revistalogos`). El alcance vive en `.sonarcloud.properties`
+(plugin + theme; `tests/` como tests). `sonar-project.properties` se ignora
+mientras Automatic Analysis esté ON. No se importa cobertura PHPUnit; el
+0.0 % del Quality Gate no es un gate de cobertura. No se añadió
+PHPStan, Psalm ni PHPCS. No cierra D12b.
+
 ## Referencias
 
 - `docs/23-testing-foundation.md` (reglas operativas)
 - `docs/24-project-testing-standard.md` (oficio: sociable-first, BDD, AAA, dobles)
+- `.sonarcloud.properties` (alcance Automatic Analysis; no es un gate de cobertura)
 - ADR 0006, 0009, 0014, 0016, 0017

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -118,6 +118,16 @@ Estado en el repo: `.github/workflows/deploy.yml` («Deploy to Hostinger») **el
 - **Producción WordPress solo desde release etiquetado:** merge a `main` no es un FTPS. GitHub Pages sigue automático. Antes de `deploy-wordpress.yml`: versionar (`package.json` / `VERSION.md` / `CHANGELOG.md`), etiqueta anotada `vX.Y.Z`, Run workflow **desde esa tag**. El workflow aborta sin ella. No disparo al pushear el tag (ADR 0009 §5 intacto). Plugin 0.2.8 live no se retiqueta; el próximo envío es un tag **nuevo**. → [ADR 0020](0020-despliegue-produccion-desde-etiqueta.md).
 - **Borrar rama al mergear:** Settings → General → Pull Requests → *Automatically delete head branches* (`delete_branch_on_merge`) **activado**. No es una regla del ruleset. `main` y las etiquetas no se tocan. Ramas remotas ya mergeadas que quedaban: eliminadas. → [ADR 0019](0019-proteger-main-trunk-based.md) § Estado de implementación.
 
+### Añadidas el 2026-08-28
+
+- **SonarQube Cloud:** Automatic Analysis (GitHub App, proyecto
+  `refo44_demo-revistalogos`). Alcance en `.sonarcloud.properties` (plugin
+  + theme; `tests/` como tests). No usar `sonar-project.properties`
+  mientras Automatic Analysis esté ON. No importa cobertura PHPUnit; el
+  0.0 % del Quality Gate es esperado. No cierra **D12b**. Un scanner en
+  `test.yml` exigiría apagar Automatic Analysis y un `SONAR_TOKEN`; no se
+  añade. Detalle: `docs/23-testing-foundation.md`.
+
 ---
 
 ## Orden sugerido

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -692,7 +692,8 @@ FSE remains deferred:
 
 D12b (checks CI de seguridad/stylelint ligados al deploy) sigue pendiente
 de la auditoría (ADR 0012 §6). El workflow `test.yml` (PHPUnit unitario)
-es Testing Foundation (ADR 0018), no cierra D12b.
+es Testing Foundation (ADR 0018), no cierra D12b. SonarQube Cloud
+Automatic Analysis (`.sonarcloud.properties`) tampoco cierra D12b.
 
 Acciones del propietario pendientes (no bloquean la QA):
 


### PR DESCRIPTION
## Summary
- Adds `.sonarcloud.properties` so Automatic Analysis scopes first-party plugin and theme sources (it ignores `sonar-project.properties`).
- Documents why Quality Gate comments show 0.0% coverage (Automatic Analysis does not import PHPUnit coverage; that is not a coverage gate, ADR 0018).
- Does not add a CI scanner: that would collide with Automatic Analysis and needs `SONAR_TOKEN` plus turning Automatic Analysis off in the Sonar UI.

## Test plan
- [ ] CI Tests check is green on this PR
- [ ] After merge to `main`, a later PR that changes plugin/theme PHP shows Sonar issues/hotspots on those files instead of an empty 0% coverage summary
- [ ] Confirm `static/` is not in the analysis scope (intentional CSS/JS duplication with the theme)


Made with [Cursor](https://cursor.com)