### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,29 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.0] — 2026-08-29
+
+Primer release etiquetado desde `v0.2.0`. Recoge la generación automática
+de PDF de artículo completa (ADR 0017 WU1–6B), su diseño editorial, el
+picker de autores, WordPress 7.1 y PHP 8.3. Habilita el FTPS a producción
+según ADR 0020: `v0.2.0` es **anterior** al 0.2.8 que ya sirve producción y
+despachar desde ella bajaría el plugin.
+
+### Security
+- `picomatch` 2.3.2 en `package-lock.json`
+  ([GHSA-3v7f-55p6-f55p], dependencia transitiva de desarrollo). Cubre
+  también GHSA-c2c7-rcm5-vvqj (ReDoS) sobre el mismo rango.
+
 ### Added
+- Plugin `revistalogos-core` 0.2.9: diseño editorial profesional del PDF de
+  artículo (`Article_Pdf_Editorial_Template`, [issue #10]). Separata
+  «Clásico filológico» en escala de grises: masthead bibliográfico
+  (Vol./N.º/año/pp./ISSN/sección leídos del número publicado), DOI, ORCID y
+  afiliación inertes, fechas en español, resúmenes y palabras clave. Los
+  campos vacíos se omiten sin etiquetas huérfanas; título + cuerpo + autores
+  sigue generando. La aplicación en publicación permanece **OFF** por
+  defecto; sin backfill ni regeneración al guardar.
+
 - Plugin `revistalogos-core` 0.2.8: Gutenberg REST publish still
   generates/persists the Article PDF; the later meta-box-loader
   request no longer clears `pdf_file` when it submits stale `0`.
@@ -131,6 +153,15 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
   bootstrap and frontend verification.
 
 ### Fixed
+- Los 8 harnesses QA de `tools/` dejan de depender de ripgrep y usan `grep`
+  POSIX. En un host sin `rg`, `if rg -q …` salía 127 y el `if` lo leía como
+  «sin coincidencias»: los guards estáticos **pasaban en silencio**. Ahora
+  se tratan explícitamente los códigos de salida de `grep` (0/1/≥2) y de
+  `find`, y la extracción de IDs usa `awk` en vez de `grep -Eo` (no POSIX).
+- `stylelint.config.mjs`: los globs de `overrides` no casaban con ninguna
+  ruta real. `tokens.css` perdía la exención que se le concede a propósito
+  (16 errores de lint) y `color-no-hex` no se aplicaba a **ningún** fichero.
+  Rutas ahora explícitas, acotadas a los dos árboles CSS del proyecto.
 - Composer lockfile vs PHP platform: `doctrine/instantiator` 2.1.0
   (`php ^8.4`) replaced with 2.0.0 so `composer install` respects
   `config.platform.php` 8.2.0 on CI PHP 8.2. PHPUnit remains 9.6.36.
@@ -299,6 +330,9 @@ con la infraestructura de gobierno del proyecto en su sitio.
 - El contenido editorial de la maqueta es demostrativo y **no** se publica en producción (ver `docs/17-implementation-order` §3.1).
 - `robots.txt` permanece en `Disallow: /` mientras el sitio es prototipo.
 
-[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.2.0...HEAD
+[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/refo44/demo-revistalogos/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/refo44/demo-revistalogos/releases/tag/v0.2.0
 [0.1.0]: https://github.com/refo44/demo-revistalogos/releases/tag/v0.1.0
+[issue #10]: https://github.com/refo44/demo-revistalogos/issues/10
+[GHSA-3v7f-55p6-f55p]: https://github.com/advisories/GHSA-3v7f-55p6-f55p

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.2.0**
+**Versión vigente: 0.3.0**
 
 ## Fuente de verdad
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",

--- a/tools/qa-article-editorial-ux.sh
+++ b/tools/qa-article-editorial-ux.sh
@@ -144,9 +144,9 @@ cli rewrite structure '/%postname%/' --hard >/dev/null
 
 PLUGIN_VERSION="$(cli eval 'echo REVISTALOGOS_CORE_VERSION;')"
 THEME_VERSION="$(cli eval 'echo REVISTALOGOS_THEME_VERSION;')"
-[[ "$PLUGIN_VERSION" == "0.2.8" ]] || fail "expected plugin 0.2.8, got $PLUGIN_VERSION"
+[[ "$PLUGIN_VERSION" == "0.2.9" ]] || fail "expected plugin 0.2.9, got $PLUGIN_VERSION"
 [[ "$THEME_VERSION" == "0.2.1" ]] || fail "expected theme 0.2.1, got $THEME_VERSION"
-pass "plugin 0.2.8 and theme 0.2.1 active in isolated WordPress"
+pass "plugin 0.2.9 and theme 0.2.1 active in isolated WordPress"
 
 echo "== PHP syntax =="
 compose run --rm --entrypoint php wpcli -l wp-content/plugins/revistalogos-core/includes/metadata/class-meta-boxes.php >/dev/null

--- a/tools/qa-article-pdf-adapter.sh
+++ b/tools/qa-article-pdf-adapter.sh
@@ -76,8 +76,8 @@ cli theme activate revistalogos >/dev/null
 cli plugin activate revistalogos-core >/dev/null
 
 PLUGIN_VERSION="$(cli eval 'echo REVISTALOGOS_CORE_VERSION;')"
-[[ "$PLUGIN_VERSION" == "0.2.8" ]] || fail "expected plugin 0.2.8, got $PLUGIN_VERSION"
-pass "plugin 0.2.8 active in isolated WordPress"
+[[ "$PLUGIN_VERSION" == "0.2.9" ]] || fail "expected plugin 0.2.9, got $PLUGIN_VERSION"
+pass "plugin 0.2.9 active in isolated WordPress"
 
 echo "== adapter publication PDF decisions =="
 cat >"$EVAL_HOST" <<'PHP'

--- a/tools/qa-article-pdf-composition.sh
+++ b/tools/qa-article-pdf-composition.sh
@@ -81,13 +81,13 @@ cli theme activate revistalogos >/dev/null
 cli plugin activate revistalogos-core >/dev/null
 
 PLUGIN_VERSION="$(cli eval 'echo REVISTALOGOS_CORE_VERSION;')"
-[[ "$PLUGIN_VERSION" == "0.2.8" ]] || fail "expected plugin 0.2.8, got $PLUGIN_VERSION"
+[[ "$PLUGIN_VERSION" == "0.2.9" ]] || fail "expected plugin 0.2.9, got $PLUGIN_VERSION"
 WP_VERSION="$(cli core version)"
 WPCLI_PHP="$(cli eval 'echo PHP_VERSION;')"
 echo "WordPress $WP_VERSION / WP-CLI PHP $WPCLI_PHP"
 [[ "$WP_VERSION" == "7.1" ]] || fail "expected WordPress 7.1, got $WP_VERSION"
 [[ "$WPCLI_PHP" == 8.3.* ]] || fail "expected WP-CLI PHP 8.3, got $WPCLI_PHP"
-pass "plugin 0.2.8 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
+pass "plugin 0.2.9 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
 
 echo "== source builder + explicit generation composition =="
 cat >"$EVAL_HOST" <<'PHP'

--- a/tools/qa-article-pdf-persistence.sh
+++ b/tools/qa-article-pdf-persistence.sh
@@ -81,13 +81,13 @@ cli theme activate revistalogos >/dev/null
 cli plugin activate revistalogos-core >/dev/null
 
 PLUGIN_VERSION="$(cli eval 'echo REVISTALOGOS_CORE_VERSION;')"
-[[ "$PLUGIN_VERSION" == "0.2.8" ]] || fail "expected plugin 0.2.8, got $PLUGIN_VERSION"
+[[ "$PLUGIN_VERSION" == "0.2.9" ]] || fail "expected plugin 0.2.9, got $PLUGIN_VERSION"
 WP_VERSION="$(cli core version)"
 WPCLI_PHP="$(cli eval 'echo PHP_VERSION;')"
 echo "WordPress $WP_VERSION / WP-CLI PHP $WPCLI_PHP"
 [[ "$WP_VERSION" == "7.1" ]] || fail "expected WordPress 7.1, got $WP_VERSION"
 [[ "$WPCLI_PHP" == 8.3.* ]] || fail "expected WP-CLI PHP 8.3, got $WPCLI_PHP"
-pass "plugin 0.2.8 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
+pass "plugin 0.2.9 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
 
 echo "== persist real Dompdf bytes + invalid-input regressions =="
 cat >"$EVAL_HOST" <<'PHP'

--- a/tools/qa-article-pdf-publication-enforcement.sh
+++ b/tools/qa-article-pdf-publication-enforcement.sh
@@ -84,13 +84,13 @@ cli theme activate revistalogos >/dev/null
 cli plugin activate revistalogos-core >/dev/null
 
 PLUGIN_VERSION="$(cli eval 'echo REVISTALOGOS_CORE_VERSION;')"
-[[ "$PLUGIN_VERSION" == "0.2.8" ]] || fail "expected plugin 0.2.8, got $PLUGIN_VERSION"
+[[ "$PLUGIN_VERSION" == "0.2.9" ]] || fail "expected plugin 0.2.9, got $PLUGIN_VERSION"
 WP_VERSION="$(cli core version)"
 WPCLI_PHP="$(cli eval 'echo PHP_VERSION;')"
 echo "WordPress $WP_VERSION / WP-CLI PHP $WPCLI_PHP"
 [[ "$WP_VERSION" == "7.1" ]] || fail "expected WordPress 7.1, got $WP_VERSION"
 [[ "$WPCLI_PHP" == 8.3.* ]] || fail "expected WP-CLI PHP 8.3, got $WPCLI_PHP"
-pass "plugin 0.2.8 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
+pass "plugin 0.2.9 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
 
 echo "== publication enforcement acceptance =="
 cat >"$EVAL_HOST" <<'PHP'

--- a/tools/qa-article-pdf-renderer.sh
+++ b/tools/qa-article-pdf-renderer.sh
@@ -100,13 +100,13 @@ cli theme activate revistalogos >/dev/null
 cli plugin activate revistalogos-core >/dev/null
 
 PLUGIN_VERSION="$(cli eval 'echo REVISTALOGOS_CORE_VERSION;')"
-[[ "$PLUGIN_VERSION" == "0.2.8" ]] || fail "expected plugin 0.2.8, got $PLUGIN_VERSION"
+[[ "$PLUGIN_VERSION" == "0.2.9" ]] || fail "expected plugin 0.2.9, got $PLUGIN_VERSION"
 WP_VERSION="$(cli core version)"
 WPCLI_PHP="$(cli eval 'echo PHP_VERSION;')"
 echo "WordPress $WP_VERSION / WP-CLI PHP $WPCLI_PHP"
 [[ "$WP_VERSION" == "7.1" ]] || fail "expected WordPress 7.1, got $WP_VERSION"
 [[ "$WPCLI_PHP" == 8.3.* ]] || fail "expected WP-CLI PHP 8.3, got $WPCLI_PHP"
-pass "plugin 0.2.8 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
+pass "plugin 0.2.9 active in isolated WordPress 7.1 / WP-CLI PHP 8.3"
 
 echo "== required PHP extensions (WP-CLI container) =="
 WPCLI_EXT="$(cli eval 'foreach ( array( "dom", "mbstring" ) as $ext ) { echo $ext, "=", extension_loaded( $ext ) ? "yes" : "no", "\n"; }')"

--- a/tools/qa-volume1-bootstrap-admin.sh
+++ b/tools/qa-volume1-bootstrap-admin.sh
@@ -130,7 +130,7 @@ VERSION_AFTER="$(cli eval 'echo get_option( Revistalogos_Core\Plugin::VERSION_OP
 [[ "$AUTHORS_BEFORE" == "$AUTHORS_AFTER" ]] || fail "upgrade mutated authors"
 [[ "$RAFAEL_STATUS" == "$RAFAEL_AFTER" && "$RAFAEL_AFTER" == "publish" ]] || fail "upgrade mutated Rafael"
 [[ "$PAGE_CONTENT_BEFORE" == "$PAGE_CONTENT_AFTER" ]] || fail "upgrade mutated institutional page"
-[[ "$VERSION_AFTER" == "0.2.8" ]] || fail "upgrade did not record plugin version 0.2.8"
+[[ "$VERSION_AFTER" == "0.2.9" ]] || fail "upgrade did not record plugin version 0.2.9"
 pass "plugin upgrade does not alter Volume 1 objects, Rafael, or Pages"
 
 FIXTURES_CLASS="$(cli eval 'echo class_exists( "Revistalogos_Core\\Fixtures" ) ? "yes" : "no";')"

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -3,7 +3,7 @@ Contributors: cenfiss
 Requires at least: 6.4
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 0.2.8
+Stable tag: 0.2.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,16 @@ Fase 3: los campos `issn`, `doi` y `orcid` son almacenamiento base inerte;
 la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 == Changelog ==
+
+= 0.2.9 =
+* Professional editorial design for the generated Article PDF
+  (`Article_Pdf_Editorial_Template`, issue #10): «Clásico filológico»
+  offprint in greyscale, bibliographic masthead (Vol./No./year/pages/ISSN/
+  section read from the published issue), inert DOI/ORCID/affiliation,
+  Spanish dates, abstracts and keywords. Empty fields are omitted without
+  orphan labels; title + body + authors still generates.
+* Publication enforcement stays OFF by default. No backfill, no
+  regenerate-on-save, no change to the author publication guard.
 
 = 0.2.8 =
 * Preserves a PDF generated on Gutenberg REST publish when the later

--- a/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Revista LOGO ET SPES — Core
  * Plugin URI:        https://github.com/refo44/demo-revistalogos
  * Description:       Modelo de contenido de la Revista de Filosofía LOGO ET SPES: números, artículos, autores, taxonomías, rol Managing Editor, migración de contenido institucional y fixtures. El theme revistalogos solo presenta; este plugin es el dueño del dominio (ADR 0005).
- * Version:           0.2.8
+ * Version:           0.2.9
  * Requires at least: 6.4
  * Tested up to:      7.1
  * Requires PHP:      7.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_CORE_VERSION', '0.2.8' );
+define( 'REVISTALOGOS_CORE_VERSION', '0.2.9' );
 define( 'REVISTALOGOS_CORE_FILE', __FILE__ );
 define( 'REVISTALOGOS_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'REVISTALOGOS_CORE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Por qué

Producción no se puede desplegar. `deploy-wordpress.yml` exige (ADR 0020 §3, `tools/require-production-release-tag.sh`) que HEAD lleve una etiqueta **anotada** `vMAJOR.MINOR.PATCH`. El último tag es `v0.2.0`, con **~100 commits detrás**, y ADR 0020 §5 lo prohíbe explícitamente: `v0.2.0` es *anterior* al plugin 0.2.8 que ya sirve producción, así que despachar desde ahí **bajaría el plugin**.

Este PR ejecuta los pasos 1–4 del procedimiento de `VERSION.md` / ADR 0020 §2. El paso 5 es mergearlo; el 6 (etiqueta anotada) y el 7 (`workflow_dispatch` desde la etiqueta) quedan para después del merge.

## Versión de proyecto: 0.2.0 → 0.3.0

**MINOR**, no PATCH. La tabla de `VERSION.md` define MINOR como «funcionalidad o contenido nuevo compatible hacia atrás», y desde `v0.2.0` entró la generación automática de PDF completa (ADR 0017 WU1–6B), su diseño editorial, el picker de autores, WordPress 7.1 y PHP 8.3. ADR 0020 §5 menciona `v0.2.1`, pero como ejemplo del formato, no como cálculo semver de este release.

## Plugin: 0.2.8 → 0.2.9 — esto no es cosmético

Al preparar el release apareció un problema real: **`f521e48` añadió 480 líneas de código de plugin sin subir la versión.**

```
class-article-pdf-editorial-template.php       | 382 +++++  (nuevo)
class-article-pdf-wordpress-source-builder.php | 155 +++--  (reescrito)
includes/class-plugin.php                      |   1 +      (wiring)
```

Producción ya sirve **0.2.8**. Desplegar este código bajo la misma cadena de versión significa que `Plugin::maybe_upgrade()` —que compara contra la opción `revistalogos_core_version` almacenada— **no se dispararía**, y el plugin instalado sería indistinguible del anterior por su versión.

De ahí el bump, que arrastra:

- `revistalogos-core.php`: cabecera `Version` y constante `REVISTALOGOS_CORE_VERSION`.
- `readme.txt`: `Stable tag` y nueva sección `= 0.2.9 =`.
- **13 asserts en 7 harnesses QA** que fijaban `"0.2.8"` (`expected plugin 0.2.8, got …`). Sin esto, los harnesses fallarían en la siguiente ejecución.

El **theme no ha cambiado** desde su bump a 0.2.1, así que su cabecera no se toca (ADR 0020 §2 paso 4: solo si cambian).

## CHANGELOG

`## [Sin publicar]` → `## [0.3.0] — 2026-08-29`, con `[Sin publicar]` vacío arriba y los enlaces de comparación actualizados. Se añaden las entradas que faltaban del trabajo reciente: plantilla editorial (issue #10), harnesses QA a `grep` POSIX (#21), `picomatch` (#22) y globs de stylelint (#23).

## Verificación

| Gate | Resultado |
|---|---|
| `./tools/php-lint.sh` | OK |
| `./tools/run-phpunit.sh` | OK — 19 tests, 88 assertions |
| `bash -n` en los 8 harnesses | OK |
| `npm run lint:css` | rc=0 |

## Después del merge

```bash
git tag -a v0.3.0 -m "v0.3.0" && git push origin v0.3.0
```

Y luego Actions → *Deploy WordPress theme+plugin to production* → Run workflow, **Use workflow from: Tags → v0.3.0**. El deploy sigue siendo `workflow_dispatch` manual; mergear esto no despliega nada.

Hay un PR complementario que añade el candado para que este olvido no se repita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)