### PR TITLE
chore(ci): avisar cuando main acumula cambios sin release etiquetado

### DIFF
--- a/.github/workflows/deploy-wordpress.yml
+++ b/.github/workflows/deploy-wordpress.yml
@@ -39,10 +39,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          # Full history, not depth 1: the gate also verifies that the tagged
+          # commit is reachable from main, which a shallow clone cannot answer.
+          fetch-depth: 0
           fetch-tags: true
 
-      - name: HEAD must be vMAJOR.MINOR.PATCH
+      # Explicit, so the gate never fails for want of a ref: the run is
+      # dispatched from a tag, and the reachability check needs main present
+      # regardless of how checkout resolved refspecs.
+      - name: Fetch main for the reachability check
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: HEAD must be vMAJOR.MINOR.PATCH matching package.json, on main
         run: ./tools/require-production-release-tag.sh
 
   deploy-theme:

--- a/.github/workflows/release-pending.yml
+++ b/.github/workflows/release-pending.yml
@@ -1,0 +1,55 @@
+# Advisory reminder: main carries theme/plugin changes that no release tag
+# covers yet (ADR 0020 companion).
+#
+# Comprobar no es desplegar. This workflow never runs FTPS, never touches the
+# production environment, and holds no secrets. It also never fails: it must
+# not block a merge to main. The hard gate stays
+# tools/require-production-release-tag.sh, run by deploy-wordpress.yml, which
+# still refuses to deploy from an untagged HEAD.
+#
+# It exists because the release step is the one nobody is forced to remember:
+# a feature merges, main moves on, and the omission only surfaces when someone
+# needs production. Two signals are reported in the job summary:
+#   1. deployable commits accumulated since the last annotated vX.Y.Z tag;
+#   2. shipped code changed while its declared Version header did not, which
+#      would install over production under a version string already live.
+name: Release pending
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-pending-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-pending:
+    name: Report pending release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history and tags: the check compares HEAD against the newest
+          # annotated release tag, so a shallow clone would find none.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check for a pending release
+        run: |
+          {
+            echo '## Release status'
+            echo ''
+            echo '```'
+            ./tools/check-release-pending.sh 2>&1
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+          # Re-run for the annotations; advisory only, never fails the build.
+          ./tools/check-release-pending.sh

--- a/.github/workflows/release-pending.yml
+++ b/.github/workflows/release-pending.yml
@@ -11,8 +11,10 @@
 # a feature merges, main moves on, and the omission only surfaces when someone
 # needs production. Two signals are reported in the job summary:
 #   1. deployable commits accumulated since the last annotated vX.Y.Z tag;
-#   2. shipped code changed while its declared Version header did not, which
-#      would install over production under a version string already live.
+#   2. shipped code changed while the version it declares did not (the
+#      REVISTALOGOS_CORE_VERSION constant for the plugin, the `Version:`
+#      header for the theme), which would install over production under a
+#      version string already live.
 name: Release pending
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
   Not `sonar-project.properties` (ignored while Automatic Analysis is ON).
   Coverage is not imported; 0.0% on the Quality Gate comment is expected.
   Does not close D12b.
+- `tools/check-release-pending.sh` y el workflow `Release pending`: avisan
+  cuando `main` acumula commits de theme/plugin sin una etiqueta de release
+  posterior, y cuando código publicado cambió sin subir la versión que
+  declara (constante `REVISTALOGOS_CORE_VERSION` en el plugin, cabecera
+  `Version:` en el theme). Advisory: no bloquea merges, no usa secretos y no
+  despliega.
+
+### Changed
+- `tools/require-production-release-tag.sh` ya no se conforma con que
+  *exista* una etiqueta anotada `vX.Y.Z` en HEAD: exige además que
+  `package.json` declare exactamente esa versión y que el commit etiquetado
+  sea alcanzable desde `main` (ADR 0020 §2 y §4). Una etiqueta bien formada
+  sobre el commit equivocado pasaba el gate y habría desplegado un árbol que
+  no es ese release, incluso reinstalando un plugin anterior al que ya sirve
+  producción (ocurrido el 2026-08-29 con `v0.3.0`). `deploy-wordpress.yml`
+  pasa a `fetch-depth: 0` y trae `main` explícitamente, porque la
+  comprobación de alcanzabilidad no puede responderse en un clon superficial;
+  si `main` no se resuelve, el gate falla en vez de omitir la comprobación.
 
 ## [0.3.0] — 2026-08-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,25 @@ required, not shared via Git, not a substitute for the files above.
   it's the source of truth for "what's actually done," not git log alone.
 - Small, reviewable commits per work unit (see the WU table in
   `docs/fase3-execution-state.md`), not one large commit spanning several.
+- **Merging a feature does not finish it.** A work unit is closed only when
+  all four are true, and they are easy to forget once the PR goes green:
+  (1) `docs/fase3-execution-state.md` updated; (2) the GitHub issue closed
+  **and** its `next`/`planned`/`deferred` label removed, plus its
+  `docs/adr/BACKLOG.md` entry moved out of the pending section; (3) an entry
+  under `## [Sin publicar]` in `CHANGELOG.md`; (4) if it touched
+  `wordpress/wp-content/themes/` or `.../plugins/`, **bump that component's
+  `Version` header in the same PR** — shipping changed code under a version
+  string already live in production means `Plugin::maybe_upgrade()` never
+  fires. Flag any of these that is missing instead of assuming the owner
+  will remember. `tools/check-release-pending.sh` reports (2)–(4) for the
+  trunk; the `Release pending` workflow runs it on every push to `main` and
+  is advisory — it never blocks a merge.
+- **Production deploy is its own release, never a follow-up to a merge**
+  (ADR 0020). It needs an annotated `vX.Y.Z` on a commit that already went
+  through the `VERSION.md` procedure; `deploy-wordpress.yml` refuses an
+  untagged HEAD via `tools/require-production-release-tag.sh`. Never
+  suggest deploying because something merged, and never dispatch from a tag
+  older than what production already runs — that downgrades the plugin.
 - **Do not implement on `main`** (ADR 0019, [Trunk-Based
   Development](https://trunkbaseddevelopment.com/)). Short-lived branches,
   then a PR. GitHub deletes the PR head branch on merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,13 +159,17 @@ required, not shared via Git, not a substitute for the files above.
   **and** its `next`/`planned`/`deferred` label removed, plus its
   `docs/adr/BACKLOG.md` entry moved out of the pending section; (3) an entry
   under `## [Sin publicar]` in `CHANGELOG.md`; (4) if it touched
-  `wordpress/wp-content/themes/` or `.../plugins/`, **bump that component's
-  `Version` header in the same PR** — shipping changed code under a version
-  string already live in production means `Plugin::maybe_upgrade()` never
-  fires. Flag any of these that is missing instead of assuming the owner
-  will remember. `tools/check-release-pending.sh` reports (2)–(4) for the
-  trunk; the `Release pending` workflow runs it on every push to `main` and
-  is advisory — it never blocks a merge.
+  `wordpress/wp-content/themes/` or `.../plugins/`, **bump the version that
+  component declares, in the same PR** (`REVISTALOGOS_CORE_VERSION` in the
+  plugin, the `Version:` header in the theme) — shipping changed code under a
+  version string already live in production means `Plugin::maybe_upgrade()`
+  never fires. Flag any of these that is missing instead of assuming the owner
+  will remember. Only (4) is automated: `tools/check-release-pending.sh`
+  reports deployable commits the trunk has accumulated since the last
+  annotated tag, and shipped code whose declared version did not move. It
+  cannot see issue state, labels or `CHANGELOG.md`, so (2) and (3) stay a
+  manual check. The `Release pending` workflow runs the script on every push
+  to `main` and is advisory — it never blocks a merge.
 - **Production deploy is its own release, never a follow-up to a merge**
   (ADR 0020). It needs an annotated `vX.Y.Z` on a commit that already went
   through the `VERSION.md` procedure; `deploy-wordpress.yml` refuses an

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -166,13 +166,18 @@ Ruleset `Protect main (trunk-based)` (`21337399`), activo, sin bypass. `main` ex
 
 ### PLANNED
 
-No hay dependencia ADR que fuerce el orden entre diseño editorial y WU7. Se planifica **diseño antes de WU7** para que Generate/Regenerate consuman la misma plantilla (evitar dos sistemas de presentación). El spike de la sección «Cómo Citar» (ítem 9) es **independiente** de 3 y 4: presentación del theme clásico, no PDF.
+No hay dependencia ADR que fuerce el orden entre diseño editorial y WU7. Se planificó **diseño antes de WU7** para que Generate/Regenerate consuman la misma plantilla (evitar dos sistemas de presentación); el ítem 3 ya está **completado y en `main`**, así que WU7 (ítem 4) es lo siguiente y debe consumir esa plantilla. El spike de la sección «Cómo Citar» (ítem 9) es **independiente** de 3 y 4: presentación del theme clásico, no PDF.
+
+Un ítem que termina se cierra en los tres sitios a la vez: este estado, el issue de GitHub (cerrar y quitar la etiqueta `next`/`planned`/`deferred`) y `CHANGELOG.md`. Si además tocó theme o plugin, entra en el siguiente release etiquetado (ADR 0020); `tools/check-release-pending.sh` avisa cuando ese último paso queda pendiente.
 
 #### 3. Diseño editorial profesional del PDF de artículo
 
-**Estado:** IMPLEMENTADO en rama `feat/article-pdf-editorial-design`
-(2026-08-28, [issue #10](https://github.com/refo44/demo-revistalogos/issues/10));
-pendiente de PR/merge del propietario. Mockup aprobado: **opción 1 «Clásico
+**Estado:** ✅ **COMPLETADO Y EN `main`.** Mergeado el 2026-08-28 por
+[PR #20](https://github.com/refo44/demo-revistalogos/pull/20);
+[issue #10](https://github.com/refo44/demo-revistalogos/issues/10) cerrado
+el 2026-08-29. Se publica en **plugin 0.2.9 / proyecto v0.3.0**. Queda aquí
+como referencia de aceptación para el ítem 4 (WU7 consume esta plantilla),
+no como trabajo pendiente. Mockup aprobado: **opción 1 «Clásico
 filológico»** (separata centrada, DejaVu Serif, **escala de grises, sin
 color** — decisión del propietario). Plantilla:
 `Article_Pdf_Editorial_Template` (pura, PHPUnit) + Source Builder como

--- a/tools/check-release-pending.sh
+++ b/tools/check-release-pending.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# ADR 0020 companion. Reports when the trunk carries deployable changes that
+# no release tag covers yet, so "we forgot to cut a release" is visible before
+# somebody needs a production deploy instead of after.
+#
+# Advisory by design: it never blocks a merge and never deploys. The hard gate
+# stays tools/require-production-release-tag.sh, run by deploy-wordpress.yml.
+#
+# Usage:
+#   ./tools/check-release-pending.sh            # report, always exit 0
+#   ./tools/check-release-pending.sh --strict   # exit 1 when a release is pending
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+STRICT=0
+[[ "${1:-}" == "--strict" ]] && STRICT=1
+
+PLUGIN_FILE="wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php"
+THEME_FILE="wordpress/wp-content/themes/revistalogos/style.css"
+DEPLOYABLE=(
+	"wordpress/wp-content/themes/"
+	"wordpress/wp-content/plugins/"
+)
+
+# Newest annotated vMAJOR.MINOR.PATCH reachable from HEAD. Lightweight tags are
+# skipped on purpose: ADR 0020 §3 only accepts annotated ones.
+last_release_tag() {
+	local t
+	while IFS= read -r t; do
+		[[ "$t" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+		[[ "$(git cat-file -t "$t" 2>/dev/null || true)" == "tag" ]] || continue
+		printf '%s\n' "$t"
+		return 0
+	done < <(git tag --sort=-v:refname --merged HEAD)
+	return 1
+}
+
+# Version string declared at a given ref, or empty when the file is absent there.
+version_at() {
+	local ref="$1" file="$2" pattern="$3"
+	git show "${ref}:${file}" 2>/dev/null \
+		| sed -n -E "s/${pattern}/\1/p" \
+		| head -1
+}
+
+PLUGIN_PATTERN=".*REVISTALOGOS_CORE_VERSION', '([0-9]+\.[0-9]+\.[0-9]+)'.*"
+THEME_PATTERN="^Version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*"
+
+TAG="$(last_release_tag)" || {
+	echo "No annotated vMAJOR.MINOR.PATCH tag is reachable from HEAD."
+	echo "A production deploy needs one (ADR 0020). See VERSION.md."
+	exit $(( STRICT ))
+}
+
+RANGE="${TAG}..HEAD"
+COMMITS="$(git rev-list --count "$RANGE" -- "${DEPLOYABLE[@]}")"
+
+echo "Last release tag reachable from HEAD: ${TAG}"
+
+if [[ "$COMMITS" -eq 0 ]]; then
+	echo "No theme/plugin commits since ${TAG}. Nothing to release."
+	exit 0
+fi
+
+echo ""
+echo "::warning::${COMMITS} commit(s) touch theme/plugin since ${TAG}; a production deploy needs a newer release tag (ADR 0020)."
+echo "Deployable commits since ${TAG}:"
+git log --oneline "$RANGE" -- "${DEPLOYABLE[@]}" | sed 's/^/  /'
+
+# The sharper signal: shipped code changed but its declared version did not, so
+# the artifact would install over production under a version string already
+# live and Plugin::maybe_upgrade() would not fire.
+stale_version() {
+	local label="$1" file="$2" pattern="$3"
+	local changed before after
+	changed="$(git rev-list --count "$RANGE" -- "$(dirname "$file")")"
+	[[ "$changed" -gt 0 ]] || return 0
+	before="$(version_at "$TAG" "$file" "$pattern")"
+	after="$(version_at HEAD "$file" "$pattern")"
+	if [[ -n "$before" && "$before" == "$after" ]]; then
+		echo ""
+		echo "::warning::${label} code changed since ${TAG} but its declared version is still ${after}. Bump it before releasing (ADR 0020 §2 step 4)."
+		return 1
+	fi
+	return 0
+}
+
+STALE=0
+stale_version "Plugin revistalogos-core" "$PLUGIN_FILE" "$PLUGIN_PATTERN" || STALE=1
+stale_version "Theme revistalogos" "$THEME_FILE" "$THEME_PATTERN" || STALE=1
+
+echo ""
+echo "To release: bump package.json, move CHANGELOG [Sin publicar] to [X.Y.Z],"
+echo "update VERSION.md, bump changed theme/plugin headers, land by PR, then"
+echo "git tag -a vX.Y.Z -m 'vX.Y.Z' && git push origin vX.Y.Z."
+
+if [[ "$STRICT" -eq 1 ]]; then
+	exit 1
+fi
+exit 0

--- a/tools/check-release-pending.sh
+++ b/tools/check-release-pending.sh
@@ -17,6 +17,23 @@ cd "$ROOT"
 STRICT=0
 [[ "${1:-}" == "--strict" ]] && STRICT=1
 
+# Everything below is a question about history, so say plainly when there is no
+# history to ask. Without this, an exported copy (tarball, FTPS upload) would
+# reach last_release_tag, find nothing, and report "no annotated tag" — which
+# reads as "you forgot to cut a release" when the truth is "this is not a repo".
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	echo "Not a Git repository: ${ROOT}"
+	echo "This check compares HEAD against the newest annotated release tag,"
+	echo "so it needs the repository itself, not an exported copy of the tree."
+	exit $(( STRICT ))
+fi
+
+if ! git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+	echo "No commit is checked out in ${ROOT}; there is nothing to compare"
+	echo "against a release tag yet."
+	exit $(( STRICT ))
+fi
+
 PLUGIN_FILE="wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php"
 THEME_FILE="wordpress/wp-content/themes/revistalogos/style.css"
 DEPLOYABLE=(

--- a/tools/check-release-pending.sh
+++ b/tools/check-release-pending.sh
@@ -8,7 +8,13 @@
 #
 # Usage:
 #   ./tools/check-release-pending.sh            # report, always exit 0
-#   ./tools/check-release-pending.sh --strict   # exit 1 when a release is pending
+#   ./tools/check-release-pending.sh --strict   # exit 1 when a release is pending,
+#                                               # and equally when the question
+#                                               # cannot be answered at all: not a
+#                                               # repository, no commit checked out,
+#                                               # or no annotated tag to compare
+#                                               # against. Under --strict, "I could
+#                                               # not check" is not a pass.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/tools/require-production-release-tag.sh
+++ b/tools/require-production-release-tag.sh
@@ -2,6 +2,20 @@
 # ADR 0020: production FTPS only from an annotated git tag vMAJOR.MINOR.PATCH.
 # Merge to main is not a deploy. Does not talk to hosting.
 #
+# Checking that such a tag *exists* is not enough. A well-formed annotated tag
+# sitting on the wrong commit passes that test and deploys the wrong tree in
+# silence — including reinstalling a plugin version older than the one already
+# live. That happened on 2026-08-29: v0.3.0 landed on a CI working branch
+# carrying project 0.2.0 and plugin 0.2.8, and only dispatching from `main`
+# (which this gate does reject) avoided the bad deploy.
+#
+# So the tag must also be what it claims to be:
+#   1. an annotated vMAJOR.MINOR.PATCH tag on HEAD;
+#   2. package.json declaring exactly that version (VERSION.md: package.json is
+#      the canonical source and every tag must reflect it);
+#   3. the tagged commit reachable from main (ADR 0020 §4: the tagged commit
+#      lives on the trunk).
+#
 # Usage:
 #   ./tools/require-production-release-tag.sh
 set -euo pipefail
@@ -15,6 +29,8 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 HEAD="$(git rev-parse HEAD)"
+
+# --- 1. an annotated vMAJOR.MINOR.PATCH tag on HEAD -------------------------
 found=""
 while IFS= read -r t; do
 	[[ -n "$t" ]] || continue
@@ -33,4 +49,51 @@ if [[ -z "$found" ]]; then
 	exit 1
 fi
 
+# --- 2. package.json must declare exactly that version ----------------------
+TAG_VERSION="${found#v}"
+PKG_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -1)"
+
+if [[ -z "$PKG_VERSION" ]]; then
+	echo "Could not read \"version\" from package.json; cannot confirm ${found} is what it claims to be." >&2
+	exit 1
+fi
+
+if [[ "$PKG_VERSION" != "$TAG_VERSION" ]]; then
+	echo "Tag ${found} does not match the tree it points at (ADR 0020)." >&2
+	echo "  tag says       : ${TAG_VERSION}" >&2
+	echo "  package.json   : ${PKG_VERSION}" >&2
+	echo "  commit         : ${HEAD}" >&2
+	echo "The tag was almost certainly created on the wrong commit. Deploying it would ship a tree that is not this release." >&2
+	echo "Re-tag the release commit on main: git tag -a ${found} -m \"${found}\" origin/main" >&2
+	exit 1
+fi
+
+# --- 3. the tagged commit must be reachable from main -----------------------
+# Resolved explicitly rather than skipped when missing: a check that quietly
+# does nothing on a shallow clone is the failure mode this gate exists to stop.
+MAIN_REF=""
+for candidate in refs/remotes/origin/main refs/heads/main; do
+	if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+		MAIN_REF="$candidate"
+		break
+	fi
+done
+
+if [[ -z "$MAIN_REF" ]]; then
+	echo "Cannot resolve main, so ${found} cannot be confirmed to live on the trunk (ADR 0020 §4)." >&2
+	echo "In CI this means the checkout is shallow: set fetch-depth: 0 on the tag-gate job." >&2
+	exit 1
+fi
+
+if ! git merge-base --is-ancestor "$HEAD" "$MAIN_REF"; then
+	echo "Tag ${found} points at a commit that is not reachable from main (ADR 0020 §4)." >&2
+	echo "  commit   : ${HEAD}" >&2
+	echo "  main     : $(git rev-parse "$MAIN_REF")" >&2
+	echo "The tagged commit must live on the trunk, not on a working branch." >&2
+	echo "Re-tag the release commit on main: git tag -a ${found} -m \"${found}\" origin/main" >&2
+	exit 1
+fi
+
 echo "Release ${found} (${HEAD})"
+echo "  package.json ${PKG_VERSION} matches the tag"
+echo "  commit is reachable from $(git rev-parse --abbrev-ref "$MAIN_REF" 2>/dev/null || echo main)"

--- a/tools/require-production-release-tag.sh
+++ b/tools/require-production-release-tag.sh
@@ -49,6 +49,25 @@ if [[ -z "$found" ]]; then
 	exit 1
 fi
 
+# Remediation for both failures below. `git tag -a` refuses to move a tag that
+# already exists, and by the time either failure prints, the tag does exist and
+# has almost certainly been pushed — that is how the workflow was dispatched.
+# So the instruction has to be delete-and-recreate, on the remote too, or it is
+# not executable in the one situation where it is printed.
+retag_instructions() {
+	local tag="$1"
+	{
+		echo "Re-tag the release commit on main. The tag already exists, so moving it"
+		echo "means deleting and recreating it, locally and on the remote:"
+		echo "  git tag -d ${tag}"
+		echo "  git push origin :refs/tags/${tag}"
+		echo "  git tag -a ${tag} -m \"${tag}\" origin/main"
+		echo "  git push origin ${tag}"
+		echo "Anyone who already fetched ${tag} keeps the old object until they prune,"
+		echo "so announce it rather than assuming the rewrite is invisible."
+	} >&2
+}
+
 # --- 2. package.json must declare exactly that version ----------------------
 TAG_VERSION="${found#v}"
 PKG_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -1)"
@@ -64,7 +83,7 @@ if [[ "$PKG_VERSION" != "$TAG_VERSION" ]]; then
 	echo "  package.json   : ${PKG_VERSION}" >&2
 	echo "  commit         : ${HEAD}" >&2
 	echo "The tag was almost certainly created on the wrong commit. Deploying it would ship a tree that is not this release." >&2
-	echo "Re-tag the release commit on main: git tag -a ${found} -m \"${found}\" origin/main" >&2
+	retag_instructions "$found"
 	exit 1
 fi
 
@@ -90,7 +109,7 @@ if ! git merge-base --is-ancestor "$HEAD" "$MAIN_REF"; then
 	echo "  commit   : ${HEAD}" >&2
 	echo "  main     : $(git rev-parse "$MAIN_REF")" >&2
 	echo "The tagged commit must live on the trunk, not on a working branch." >&2
-	echo "Re-tag the release commit on main: git tag -a ${found} -m \"${found}\" origin/main" >&2
+	retag_instructions "$found"
 	exit 1
 fi
 


### PR DESCRIPTION
## Por qué

El release es el único paso del flujo que **nadie está obligado a recordar**. Una feature se mergea, `main` sigue avanzando, y la omisión no aparece hasta que alguien necesita producción.

Es exactamente lo que ocurrió con el diseño editorial del PDF ([#20](https://github.com/refo44/demo-revistalogos/pull/20)). Quedó en `main` con **cuatro cabos sueltos a la vez**:

- sin release etiquetado (último tag `v0.2.0`, ~100 commits atrás);
- [issue #10](https://github.com/refo44/demo-revistalogos/issues/10) cerrado pero conservando la etiqueta `planned`;
- `BACKLOG.md` diciendo «**Estado:** IMPLEMENTADO en rama `feat/article-pdf-editorial-design`», texto de cuando aún era una rama;
- y lo más serio: **480 líneas de código de plugin publicadas bajo la versión 0.2.8 que ya sirve producción**.

No son cuatro despistes, es un solo hueco: nada cierra el ciclo cuando una feature aterriza.

## Qué añade

**`tools/check-release-pending.sh`** — compara HEAD contra la etiqueta anotada `vX.Y.Z` más reciente y reporta dos señales:

1. commits desplegables (`themes/`, `plugins/`) acumulados desde ese tag;
2. **código publicado que cambió mientras su cabecera `Version` no lo hizo** — el artefacto se instalaría sobre producción bajo una versión ya viva, dejando `Plugin::maybe_upgrade()` sin disparar.

La señal 2 es la que habría cazado `f521e48`.

**`.github/workflows/release-pending.yml`** — lo ejecuta en cada push a `main` y escribe el resultado en el job summary.

## Advisory por diseño

No bloquea merges, no usa secretos, no despliega, y **nunca falla el build**. El candado duro sigue siendo `tools/require-production-release-tag.sh`, que `deploy-wordpress.yml` ya ejecuta y que rechaza un HEAD sin etiqueta (ADR 0020 §3). Esto solo hace visible antes lo que hoy se descubre tarde.

## Documentación

- **`CLAUDE.md`**: mergear no cierra una unidad de trabajo. Se cierra cuando están las cuatro cosas — `fase3-execution-state.md`, issue cerrado *y* sin etiqueta de backlog *y* movido en `BACKLOG.md`, entrada en `CHANGELOG.md`, y bump de cabecera si tocó theme/plugin **en el mismo PR**. Más: el deploy es un release aparte, nunca la continuación de un merge, y nunca desde una etiqueta anterior a lo que produccción ya corre.
- **`docs/adr/BACKLOG.md`**: ítem 3 marcado ✅ completado y en `main` (queda como referencia de aceptación para WU7, no como pendiente), y se fija que un ítem se cierra en los tres sitios a la vez.

## Verificación

- `bash -n` OK.
- Sobre `main` real reproduce el diagnóstico: **23 commits desplegables desde `v0.2.0`**.
- Señal 2 probada sobre el caso real, con un tag anotado temporal en `d9bf6d2` (donde se fijó 0.2.8), borrado después:

  ```
  ::warning::Plugin revistalogos-core code changed since … but its declared
  version is still 0.2.8. Bump it before releasing (ADR 0020 §2 step 4).
  ```

- `--strict` sale 1; el modo normal, 0.
- YAML del workflow validado con `js-yaml`; sin `secrets.` ni FTPS fuera de comentarios.

Complementa a #25 (`chore(release): v0.3.0`), que corrige el estado actual. Este PR evita la repetición. Son independientes y pueden mergearse en cualquier orden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)