### PR TITLE
ci(test): ejecutar stylelint con el Node de .nvmrc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,10 @@
-# PHP lint, Composer lockfile audit, PHPUnit units (Testing Foundation, ADR 0018).
+# PHP lint, Composer lockfile audit, PHPUnit units (Testing Foundation, ADR 0018)
+# and Stylelint over the two CSS trees.
+#
+# The CSS job exists because nothing in CI ran Node until now: `lint:css`, the
+# `engines` floor, and every lockfile change were verified only on whatever
+# machine happened to run them. It resolves its Node from `.nvmrc` so CI and
+# the laptop agree.
 #
 # Comprobar no es desplegar: no FTPS, no Pages, no production environment,
 # no secrets. Does not close D12b (security-audit automation). WordPress
@@ -69,3 +75,29 @@ jobs:
 
       - name: Run unit tests
         run: composer test:unit
+
+  css-lint:
+    name: Stylelint (Node from .nvmrc)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # node-version-file reads .nvmrc, so CI and the developer laptop resolve
+      # the same version. package.json `engines` requires >=20.19.0 (stylelint
+      # 17 and the @csstools tree); npm reports EBADENGINE below that.
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      # `npm ci` installs strictly from the lockfile and fails when it has
+      # drifted from package.json, which `npm install` would instead paper
+      # over by rewriting the lockfile in place.
+      - name: Install dependencies from the lockfile
+        run: npm ci
+
+      - name: Lint CSS
+        run: npm run lint:css

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,8 +96,12 @@ jobs:
       # `npm ci` installs strictly from the lockfile and fails when it has
       # drifted from package.json, which `npm install` would instead paper
       # over by rewriting the lockfile in place.
+      #
+      # --ignore-scripts keeps dependency lifecycle scripts from executing on
+      # the runner (Sonar githubactions:S6505). Stylelint is pure JavaScript
+      # with nothing to build at install time, so the lint runs unchanged.
       - name: Install dependencies from the lockfile
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Lint CSS
         run: npm run lint:css


### PR DESCRIPTION
## El aviso que originó esto era una falsa alarma

Reporté un `EBADENGINE` en local (`node 20.17.0` frente a `engines >=20.19.0`) y sugerí alinearlo. Al investigarlo, **el repo ya estaba alineado**:

- `engines: >=20.19.0` es correcto y no sobra — lo exigen `stylelint` 17.4.0, `stylelint-config-standard` 40 y todo el árbol `@csstools/*`. Bajarlo habría sido mentir sobre lo que necesita el toolchain.
- `.nvmrc` es `lts/*`; `nvm use` selecciona **v22.14.0**, que lo satisface. Cero avisos.

El aviso salía de un shell que no había hecho `nvm use`. **No hacía falta cambiar ninguna versión.**

## El hueco real

Investigándolo apareció algo que sí importa: **nada en CI ejecutaba Node.** Ni `setup-node`, ni `npm ci`, ni `npm run`. Consecuencias concretas, todas ya materializadas:

- El arreglo de los globs de stylelint ([#23](https://github.com/refo44/demo-revistalogos/pull/23)) se mergeó **sin que CI llegara a ejecutar la regla que reactivaba**.
- El desajuste de versión del lockfile ([#25](https://github.com/refo44/demo-revistalogos/pull/25)) lo encontró una revisión, no un job.
- El suelo de `engines` no se comprueba en ninguna parte.

`lint:css` existía como script pero solo corría en la máquina que casualmente lo lanzara.

## Qué añade

Un job `css-lint` en `test.yml`:

- `node-version-file: .nvmrc` — CI y el portátil resuelven la misma versión, en vez de fijar un número que se desincronice.
- `npm ci` — estricto contra el lockfile, a diferencia de `npm install`, que lo reescribiría en silencio.
- `npm run lint:css`.

## Sin impacto en el ruleset

El check requerido («PHP lint, Composer audit, and unit (PHP 8.3)») **no cambia de nombre ni de contenido**. `css-lint` entra como check adicional **no requerido**; convertirlo en requerido es una decisión aparte que no tomo aquí.

## Verificación

Con el Node que resuelve `.nvmrc` (v22.14.0):

| | |
|---|---|
| `npm ci` | rc=0 |
| avisos `EBADENGINE` | **0** |
| `npm run lint:css` | rc=0 |

YAML validado con `js-yaml`. `actions/setup-node@v7` comprobado contra la API como major existente y con notas de versión sin cambios incompatibles en `node-version-file` ni `cache` (es migración a ESM); se elige v7 por coherencia con `actions/checkout@v7` ya en uso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)