### PR TITLE
docs: alinear README, procedimiento de release y estándar de testing con main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
   despliega.
 
 ### Changed
+- Los pies de `docs/` dejan de repetir la versión del proyecto. Siete
+  documentos declaraban `0.2.0` mientras `package.json` iba por 0.3.0, y
+  ningún paso del procedimiento de publicación los tocaba. Los 26 pies
+  quedan uniformes como `**Proyecto:** Revista de Filosofía LOGO ET SPES`;
+  la versión vive solo donde es canónica. El `**Versión:**` de cada
+  documento es su propia revisión y no cambia.
 - `tools/require-production-release-tag.sh` ya no se conforma con que
   *exista* una etiqueta anotada `vX.Y.Z` en HEAD: exige además que
   `package.json` declare exactamente esa versión y que el commit etiquetado

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,12 @@ required, not shared via Git, not a substitute for the files above.
   domain behavior uses TDD. For PHP changes, before completion: (1) syntax
   gate `./tools/php-lint.sh` or `composer lint:php`; (2) Composer lockfile
   audit `composer audit:deps` (`composer audit --locked`); (3) relevant
-  PHPUnit (`composer test:unit` or `./tools/run-phpunit.sh`); (4) relevant
-  `tools/qa-*.sh` if WordPress integration behavior changed. `composer test`
-  runs lint, audit, then units — not acceptance harnesses. Root
+  PHPUnit units (`composer test:unit` or `./tools/run-phpunit.sh`);
+  (4) `composer test:wp` / `./tools/run-phpunit-wp.sh` when an in-process
+  WordPress contract changed (meta, CPT, adapter, source builder, block
+  `render_callback`); (5) the relevant `tools/qa-*.sh` if HTTP, wp-admin
+  or plugin CLI behavior changed. `composer test` runs lint, audit, then
+  units — not `test:wp` and not acceptance harnesses. Root
   `composer.json` is test-only. Composer audit does not scan WordPress,
   npm, or hosting. Dependabot may open weekly Composer and GitHub Actions
   PRs; they are not auto-merged. Review them after CI. Do not treat a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,8 +163,12 @@ required, not shared via Git, not a substitute for the files above.
   `docs/adr/BACKLOG.md` entry moved out of the pending section; (3) an entry
   under `## [Sin publicar]` in `CHANGELOG.md`; (4) if it touched
   `wordpress/wp-content/themes/` or `.../plugins/`, **bump the version that
-  component declares, in the same PR** (`REVISTALOGOS_CORE_VERSION` in the
-  plugin, the `Version:` header in the theme) — shipping changed code under a
+  component declares, in the same PR** — the theme only in `Version:` of
+  `style.css`; the plugin in three places that must stay identical: the
+  `Version:` header and `REVISTALOGOS_CORE_VERSION` in
+  `revistalogos-core.php`, plus `Stable tag:` in its `readme.txt`
+  (`maybe_upgrade()` compares the constant, wp-admin shows the header, and
+  `check-release-pending.sh` only reads the constant) — shipping changed code under a
   version string already live in production means `Plugin::maybe_upgrade()`
   never fires. Flag any of these that is missing instead of assuming the owner
   will remember. Only (4) is automated: `tools/check-release-pending.sh`

--- a/README.md
+++ b/README.md
@@ -70,9 +70,12 @@ Dos reglas que evitan los dos errores que este flujo permite (ADR 0020):
    etiquetado*, no de «lo último de `main`». Antes de desplegar: subir
    `"version"` en `package.json`, pasar `CHANGELOG.md` de
    `## [Sin publicar]` a `## [X.Y.Z]`, actualizar `VERSION.md`, subir la
-   versión que declara el theme o el plugin **si cambiaron** (`Version:` en
-   el `style.css` del theme; la constante `REVISTALOGOS_CORE_VERSION` en el
-   plugin), aterrizar por PR `chore(release): vX.Y.Z`, y solo entonces:
+   versión que declara el theme o el plugin **si cambiaron** —el theme solo
+   en `Version:` de `style.css`; el plugin en **tres sitios que deben quedar
+   iguales**: la cabecera `Version:` y la constante
+   `REVISTALOGOS_CORE_VERSION` de `revistalogos-core.php`, más `Stable tag:`
+   de su `readme.txt`—, aterrizar por PR `chore(release): vX.Y.Z`, y solo
+   entonces:
 
    ```bash
    git fetch --tags origin main
@@ -112,7 +115,7 @@ git show vX.Y.Z:package.json | grep '"version"'
 ```
 
 ```bash
-git merge-base --is-ancestor vX.Y.Z origin/main && echo "en main" || echo "NO está en main"
+git merge-base --is-ancestor vX.Y.Z origin/main && echo "en main" || { echo "NO está en main"; false; }
 ```
 
 **Prototipo estático:** abrir `static/index.html` en un navegador (sin build).

--- a/README.md
+++ b/README.md
@@ -70,26 +70,42 @@ Dos reglas que evitan los dos errores que este flujo permite (ADR 0020):
    etiquetado*, no de «lo último de `main`». Antes de desplegar: subir
    `"version"` en `package.json`, pasar `CHANGELOG.md` de
    `## [Sin publicar]` a `## [X.Y.Z]`, actualizar `VERSION.md`, subir la
-   cabecera `Version` del theme o del plugin **si cambiaron**, aterrizar por
-   PR `chore(release): vX.Y.Z`, y solo entonces:
+   versión que declara el theme o el plugin **si cambiaron** (`Version:` en
+   el `style.css` del theme; la constante `REVISTALOGOS_CORE_VERSION` en el
+   plugin), aterrizar por PR `chore(release): vX.Y.Z`, y solo entonces:
 
    ```bash
+   git fetch --tags origin main
    git tag -a vX.Y.Z -m "vX.Y.Z" origin/main && git push origin vX.Y.Z
    ```
+
+   El `fetch` no es ceremonia: `origin/main` es una copia local y, si está
+   vieja, la etiqueta acaba en un commit que no es el del release.
 
 2. **Al lanzar el workflow, en *Use workflow from* elegir `Tags → vX.Y.Z`,
    nunca `main`.** El gate (`tools/require-production-release-tag.sh`) exige
    una etiqueta anotada en HEAD, así que despachar desde `main` falla y
    nada se sube — molesto, pero seguro.
 
-**El fallo peligroso es el otro:** el gate comprueba que *exista* una
-etiqueta anotada `vX.Y.Z` en HEAD, **no** que su contenido corresponda a esa
-versión. Una etiqueta bien formada pero puesta en el commit equivocado
-—por ejemplo sobre una rama de trabajo en vez de sobre el commit del
-release— **pasa el gate y despliega el código equivocado en silencio**,
-incluso reinstalando sobre producción una versión de plugin anterior a la
-que ya sirve. Ocurrió el 2026-08-29 con `v0.3.0`. Antes de desplegar,
-verificar que la etiqueta es lo que dice ser:
+**El otro error era peor, y hasta hace poco nada lo frenaba:** el gate
+comprobaba que *exista* una etiqueta anotada `vX.Y.Z` en HEAD, no que su
+contenido correspondiera a esa versión. Una etiqueta bien formada sobre el
+commit equivocado —sobre una rama de trabajo en vez de sobre el commit del
+release— pasaba, y habría desplegado el código equivocado en silencio,
+reinstalando sobre producción una versión de plugin anterior a la que ya
+sirve. Ocurrió el 2026-08-29 con `v0.3.0`.
+
+Desde ese mismo día el gate lo verifica: exige además que `package.json`
+declare exactamente la versión de la etiqueta y que el commit etiquetado
+sea alcanzable desde `main`. Aun así conviene comprobarlo **antes** de
+etiquetar, por dos razones: el gate falla cuando la etiqueta ya está
+publicada y el run despachado, y deshacer eso obliga a borrarla y recrearla
+en local y en el remoto; y hay algo que el gate no puede saber, que es qué
+versión de plugin corre producción ahora mismo.
+
+```bash
+git fetch --tags origin main
+```
 
 ```bash
 git show vX.Y.Z:package.json | grep '"version"'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Revista de Filosofía LOGO ET SPES
 
-**Versión:** 0.2.0 (canónica en `package.json`; ver `VERSION.md` y `CHANGELOG.md`)
+**Versión:** 0.3.0 (canónica en `package.json`; ver `VERSION.md` y `CHANGELOG.md`)
 
 Monorepo de la revista académica (CENFISS): prototipo HTML estático (`static/`,
 Fase 2, base visual congelada) y WordPress (`wordpress/`, Fase 3 clásica).

--- a/README.md
+++ b/README.md
@@ -61,14 +61,51 @@ El detalle de las plantillas estáticas y su mapeo a WordPress está en
 persistido; hace falta `wp core update` + `wp core update-db`.
 
 **Producción WordPress:** `https://logo-et-spes.cenfiss.net`. Solo
-`deploy-wordpress.yml` (manual). No hay staging WordPress. Ver
+`deploy-wordpress.yml` (manual). No hay staging WordPress. Runbook completo:
 `docs/operations/wordpress-manual-deployment.md`.
+
+Dos reglas que evitan los dos errores que este flujo permite (ADR 0020):
+
+1. **Mergear a `main` no despliega.** Producción sale de un *release
+   etiquetado*, no de «lo último de `main`». Antes de desplegar: subir
+   `"version"` en `package.json`, pasar `CHANGELOG.md` de
+   `## [Sin publicar]` a `## [X.Y.Z]`, actualizar `VERSION.md`, subir la
+   cabecera `Version` del theme o del plugin **si cambiaron**, aterrizar por
+   PR `chore(release): vX.Y.Z`, y solo entonces:
+
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z" origin/main && git push origin vX.Y.Z
+   ```
+
+2. **Al lanzar el workflow, en *Use workflow from* elegir `Tags → vX.Y.Z`,
+   nunca `main`.** El gate (`tools/require-production-release-tag.sh`) exige
+   una etiqueta anotada en HEAD, así que despachar desde `main` falla y
+   nada se sube — molesto, pero seguro.
+
+**El fallo peligroso es el otro:** el gate comprueba que *exista* una
+etiqueta anotada `vX.Y.Z` en HEAD, **no** que su contenido corresponda a esa
+versión. Una etiqueta bien formada pero puesta en el commit equivocado
+—por ejemplo sobre una rama de trabajo en vez de sobre el commit del
+release— **pasa el gate y despliega el código equivocado en silencio**,
+incluso reinstalando sobre producción una versión de plugin anterior a la
+que ya sirve. Ocurrió el 2026-08-29 con `v0.3.0`. Antes de desplegar,
+verificar que la etiqueta es lo que dice ser:
+
+```bash
+git show vX.Y.Z:package.json | grep '"version"'
+```
+
+```bash
+git merge-base --is-ancestor vX.Y.Z origin/main && echo "en main" || echo "NO está en main"
+```
 
 **Prototipo estático:** abrir `static/index.html` en un navegador (sin build).
 El espejo beta es GitHub Pages (`pages.yml`). El workflow estático
 «Deploy to Hostinger» (`deploy.yml`) **está retirado**; no recrearlo.
 
-**Lint CSS:** `npm run lint:css`.
+**Lint CSS:** `nvm use` (respeta `.nvmrc`) y luego `npm run lint:css`.
+`package.json` exige `node >=20.19.0` por stylelint 17; con una versión
+inferior npm avisa `EBADENGINE`.
 
 **Tests (ADR 0018, `docs/23-testing-foundation.md`, `docs/24-project-testing-standard.md`):** PHP syntax
 `./tools/php-lint.sh` / `composer lint:php` (`php -l` only). Composer

--- a/VERSION.md
+++ b/VERSION.md
@@ -37,12 +37,17 @@ desde la etiqueta, no desde HEAD suelto de `main`.
 4. Si el theme o el plugin cambian en ese release, subir sus cabeceras
    `Version` / `Stable tag` (pueden diferir de X.Y.Z).
 5. Commit por PR: `chore(release): vX.Y.Z` (ADR 0019: no pushear a `main`).
-6. Etiquetar: `git tag -a vX.Y.Z -m "vX.Y.Z"` y `git push origin vX.Y.Z`.
+6. Etiquetar **sobre el commit del release ya en `main`**:
+   `git tag -a vX.Y.Z -m "vX.Y.Z" origin/main` y `git push origin vX.Y.Z`.
+   Etiquetar el HEAD local sin comprobar dónde está apunta a la rama en la
+   que se esté trabajando: el gate del deploy acepta esa etiqueta igualmente
+   y desplegaría el contenido equivocado.
 7. Desplegar theme+plugin desde GitHub Actions → «Deploy WordPress theme+plugin
    to production» → Run workflow **desde esa etiqueta** (Use workflow from:
    Tags). El workflow falla si HEAD no tiene `vMAJOR.MINOR.PATCH` anotada.
    El workflow estático «Deploy to Hostinger» (`deploy.yml`) está **retirado**;
-   no recrearlo. No despachar desde `v0.2.0`: producción ya sirve plugin 0.2.8.
+   no recrearlo. Nunca despachar desde una etiqueta anterior a lo que
+   producción ya sirve: reinstalaría una versión más vieja del plugin.
 
 ## Historial
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -34,14 +34,27 @@ desde la etiqueta, no desde HEAD suelto de `main`.
 1. Actualizar `"version"` en `package.json`.
 2. Mover los cambios de `## [Sin publicar]` a una nueva sección `## [X.Y.Z] — AAAA-MM-DD` en `CHANGELOG.md`.
 3. Actualizar «Versión vigente» en este archivo.
-4. Si el theme o el plugin cambian en ese release, subir sus cabeceras
-   `Version` / `Stable tag` (pueden diferir de X.Y.Z).
+4. Si el theme o el plugin cambian en ese release, subir la versión que
+   declara cada uno (pueden diferir de X.Y.Z): `Version:` y `Stable tag:`
+   en el `style.css` del theme, y la constante `REVISTALOGOS_CORE_VERSION`
+   en el plugin — no una cabecera.
 5. Commit por PR: `chore(release): vX.Y.Z` (ADR 0019: no pushear a `main`).
-6. Etiquetar **sobre el commit del release ya en `main`**:
-   `git tag -a vX.Y.Z -m "vX.Y.Z" origin/main` y `git push origin vX.Y.Z`.
+6. Etiquetar **sobre el commit del release ya en `main`**, con las refs
+   recién traídas:
+
+   ```bash
+   git fetch --tags origin main
+   git tag -a vX.Y.Z -m "vX.Y.Z" origin/main
+   git push origin vX.Y.Z
+   ```
+
    Etiquetar el HEAD local sin comprobar dónde está apunta a la rama en la
-   que se esté trabajando: el gate del deploy acepta esa etiqueta igualmente
-   y desplegaría el contenido equivocado.
+   que se esté trabajando; sin el `fetch`, `origin/main` puede estar vieja y
+   apuntar a un commit anterior al release. Desde el 2026-08-29 el gate del
+   deploy rechaza una etiqueta así —comprueba que `package.json` declare la
+   versión de la etiqueta y que el commit esté en `main`—, pero para
+   entonces ya está publicada, y corregirla obliga a borrarla y recrearla en
+   local y en el remoto.
 7. Desplegar theme+plugin desde GitHub Actions → «Deploy WordPress theme+plugin
    to production» → Run workflow **desde esa etiqueta** (Use workflow from:
    Tags). El workflow falla si HEAD no tiene `vMAJOR.MINOR.PATCH` anotada.

--- a/VERSION.md
+++ b/VERSION.md
@@ -7,6 +7,14 @@
 El número de versión canónico vive en **`package.json`** (`"version"`). Todo lo demás
 —etiquetas de Git, `CHANGELOG.md`, este documento— debe reflejar ese valor.
 
+Los documentos de `docs/` **no** repiten la versión del proyecto. Su pie es
+`**Proyecto:** Revista de Filosofía LOGO ET SPES`, sin número; el `**Versión:**`
+que llevan encima es la revisión **del propio documento**, que evoluciona aparte.
+Siete pies llegaron a copiar `0.2.0` y se quedaron ahí mientras el proyecto pasaba
+a 0.3.0: ningún paso de este procedimiento los tocaba, y no lo va a tocar. Un
+número copiado en un sitio que nadie actualiza no informa, desinforma. No volver a
+añadirlo.
+
 ## Esquema
 
 Versionado Semántico `MAJOR.MINOR.PATCH` ([semver.org](https://semver.org/lang/es/)):

--- a/VERSION.md
+++ b/VERSION.md
@@ -35,9 +35,19 @@ desde la etiqueta, no desde HEAD suelto de `main`.
 2. Mover los cambios de `## [Sin publicar]` a una nueva sección `## [X.Y.Z] — AAAA-MM-DD` en `CHANGELOG.md`.
 3. Actualizar «Versión vigente» en este archivo.
 4. Si el theme o el plugin cambian en ese release, subir la versión que
-   declara cada uno (pueden diferir de X.Y.Z): `Version:` y `Stable tag:`
-   en el `style.css` del theme, y la constante `REVISTALOGOS_CORE_VERSION`
-   en el plugin — no una cabecera.
+   declara cada uno (pueden diferir de X.Y.Z):
+
+   | Componente | Dónde | Quién la lee |
+   |---|---|---|
+   | Theme | `Version:` en `style.css` | wp-admin → Apariencia |
+   | Plugin | `Version:` en `revistalogos-core.php` | wp-admin → Plugins |
+   | Plugin | `REVISTALOGOS_CORE_VERSION` en ese mismo archivo | `Plugin::maybe_upgrade()` |
+   | Plugin | `Stable tag:` en `readme.txt` | metadatos del plugin |
+
+   **Los tres del plugin deben quedar iguales.** `maybe_upgrade()` compara
+   la constante y wp-admin muestra la cabecera: si divergen, el panel
+   informa de una versión que no es la que decide si el upgrade corre. El
+   theme no tiene `Stable tag:` ni `readme.txt`; no buscarlos.
 5. Commit por PR: `chore(release): vX.Y.Z` (ADR 0019: no pushear a `main`).
 6. Etiquetar **sobre el commit del release ya en `main`**, con las refs
    recién traídas:

--- a/docs/00-order-documents.md
+++ b/docs/00-order-documents.md
@@ -128,4 +128,4 @@ Estos principios aplican independientemente del tipo de sitio (comunidad, autor,
 ---
 
 **Versión:** 1.2  
-**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES

--- a/docs/13-static-file-structure.md
+++ b/docs/13-static-file-structure.md
@@ -185,4 +185,4 @@ Este repositorio contiene:
 ---
 
 **Versión:** 1.1  
-**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES

--- a/docs/15-assets-strategy.md
+++ b/docs/15-assets-strategy.md
@@ -156,4 +156,4 @@ assets/
 ---
 
 **Versión:** 1.1  
-**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES

--- a/docs/17-implementation-order.md
+++ b/docs/17-implementation-order.md
@@ -217,4 +217,4 @@ No forma parte del cierre de Fase 3 ni de Fase 4. **Hoy** el PDF de artículo se
 ---
 
 **Versión:** 1.3
-**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES

--- a/docs/23-testing-foundation.md
+++ b/docs/23-testing-foundation.md
@@ -371,4 +371,4 @@ ADR 0017 work unit 1 ya tiene la política pura; no adelantar
 `PdfGenerator` ni librerías PDF hasta la unidad de renderer.
 
 **Versión:** 1.3
-**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES

--- a/docs/23-testing-foundation.md
+++ b/docs/23-testing-foundation.md
@@ -84,6 +84,13 @@ Hoy: dos mecanismos, ambos Docker aislado contra WordPress **7.1**.
 2. **Harnesses** `tools/qa-*.sh` para flujos integrados completos
    (HTTP, wp-admin, CLI del plugin).
 
+**Cuándo cuál (nivel 2):** un contrato WordPress que se ejercita en PHP
+(mapeo post/meta/taxonomía, registro CPT, adaptador, `render_callback`)
+va a `tests/WordPress/` y `composer test:wp`. Un flujo HTTP, pantalla
+wp-admin o comando CLI del plugin va a `tools/qa-*.sh`. No reescribir
+un harness HTTP a PHPUnit por uniformidad. No usar un harness para
+evitar wp-phpunit en un mapeo in-process.
+
 No fingir APIs de WordPress cuando el objeto de la prueba es el comportamiento
 de WordPress.
 
@@ -114,7 +121,7 @@ con `--no-dev` y lo sube.
 - Runner: **PHPUnit 9.6** (`phpunit/phpunit`, `require-dev`).
 - Sintaxis: nativo `php -l` vía `tools/php-lint.sh` / `composer lint:php`. Sin PHPStan, Psalm ni PHPCS. SonarQube Cloud es Automatic Analysis (`.sonarcloud.properties`), no sustituye esos linters ni cierra D12b.
 - `composer test` = lint PHP + `composer audit --locked` + suite unitaria.
-  No ejecuta `tools/qa-*.sh`.
+  No ejecuta `composer test:wp` ni `tools/qa-*.sh`.
 - Composer de raíz: **solo** tooling de test. El plugin carga su
   `vendor/autoload.php` si existe y sigue usando `require_once` para
   código propio (ADR 0006). El workflow FTPS sube el `vendor/` generado
@@ -163,11 +170,15 @@ PHPUnit no replica estos flujos enteros.
   hooks internos salvo que el hook sea el contrato público.
 - ADR 0017 work unit 1: `tests/Features/article-pdf-generation.feature`
   (especificación de negocio; sin Behat). La política pura se verifica
-  en PHPUnit. El cableado WordPress y el renderer siguen pendientes.
+  en PHPUnit nivel 1. El renderer concreto, en
+  `ArticlePdfDompdfRendererTest` y `tools/qa-article-pdf-renderer.sh`.
+  El cableado WordPress del source builder, en `tests/WordPress/`
+  (`composer test:wp`).
 
-Gherkin describe comportamiento observable. PHPUnit verifica PHP. Los
-harnesses verifican el flujo integrado. Pueden complementarse; no hace falta
-una traza 1:1.
+Gherkin describe comportamiento observable. PHPUnit nivel 1 verifica PHP
+puro. `composer test:wp` verifica contratos WordPress in-process. Los
+harnesses verifican el flujo HTTP/admin/CLI. Pueden complementarse; no
+hace falta una traza 1:1.
 
 ## TDD (dominio nuevo)
 
@@ -273,10 +284,11 @@ composer test          # lint → audit --locked → units; not qa-*.sh
 ```
 
 `php -l` comprueba **sintaxis**. `composer audit --locked` comprueba
-**advisories del lockfile de Composer**. PHPUnit comprueba
-**comportamiento**. Los `qa-*.sh` comprueban **WordPress integrado**. Los
-harnesses que ya llaman `php -l` sobre archivos sueltos se conservan; el
-gate global los complementa.
+**advisories del lockfile de Composer**. PHPUnit nivel 1 comprueba
+**comportamiento puro**. `composer test:wp` comprueba **contratos
+WordPress in-process**. Los `qa-*.sh` comprueban **HTTP / wp-admin /
+CLI**. Los harnesses que ya llaman `php -l` sobre archivos sueltos se
+conservan; el gate global los complementa.
 
 La suite PHPUnit/WP existe desde 2026-08-28 como `composer test:wp`
 (`./tools/run-phpunit-wp.sh`). No entra en `composer test` ni en CI:
@@ -351,10 +363,12 @@ dependencias runtime. Antes de un deploy WU4: verificar `ext-dom` y
 
 ## Expansión futura
 
-Añadir una herramienta (Behat, Brain Monkey, Playwright, suite WP oficial,
-matriz de versiones) solo con necesidad arquitectónica demostrada. ADR 0017
-work unit 1 ya tiene la política pura; no adelantar `PdfGenerator` ni
-librerías PDF hasta la unidad de renderer.
+Añadir una herramienta (Behat, Brain Monkey, Playwright, wp-env,
+wp-browser, matriz de versiones) solo con necesidad arquitectónica
+demostrada. `wp-phpunit` **ya es** el runner de nivel 2 in-process; no
+sustituirlo por wp-env ni por una segunda suite en `tests/Integration/`.
+ADR 0017 work unit 1 ya tiene la política pura; no adelantar
+`PdfGenerator` ni librerías PDF hasta la unidad de renderer.
 
-**Versión:** 1.2
+**Versión:** 1.3
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/24-project-testing-standard.md
+++ b/docs/24-project-testing-standard.md
@@ -5,7 +5,8 @@ WordPress clásico). Complementa [23-testing-foundation](23-testing-foundation.m
 (taxonomía, CI, comandos) y no reescribe [ADR 0018](adr/0018-testing-foundation.md).
 
 **Aplica a:** `tests/Unit/**/*Test.php`, `tests/Support/**/*.php`,
-`tests/Features/**/*.feature`, `tools/qa-*.sh`
+`tests/WordPress/**/*Test.php`, `phpunit-wp.xml.dist`,
+`tests/Features/**/*.feature`, `tools/qa-*.sh`, `tools/run-phpunit-wp.sh`
 
 **`.cursor/` está gitignored a propósito.** Si un desarrollador mantiene
 reglas Cursor locales, son espejos opcionales: no son fuente de verdad, no
@@ -21,10 +22,10 @@ se versionan, no se exigen en otros clones ni en CI.
 | ¿Qué asertar? | **Resultados observables** por métodos públicos, HTTP o comportamiento wp-admin |
 | ¿Qué evitar? | `expects()` / `method()` / orden de llamadas sobre colaboradores **internos** |
 | ¿Cómo estructurar? | Plano, autocontenido, nombre de comportamiento + cuerpo AAA, sin estado mutable compartido |
-| ¿Cuándo arrancar WordPress? | Integración estrecha/amplia vía `tools/qa-*.sh` aislado — no en cada unitario sociable |
+| ¿Cuándo arrancar WordPress? | Contrato WP in-process → `tests/WordPress/` (`composer test:wp`). HTTP / wp-admin / CLI → `tools/qa-*.sh` aislado. Nunca en `tests/Unit/` |
 | ¿Cuándo vale un test solitario? | Lógica pura con ramificación compleja donde el aislamiento aclara |
 | ¿Puerta de calidad? | **Conductual** + **insensible a la estructura** |
-| ¿Cómo correr la suite? | `composer test` (lint + audit + units); **un** `tools/qa-*.sh` relevante si cambió WordPress |
+| ¿Cómo correr la suite? | `composer test` (lint + audit + units); `composer test:wp` si cambió un contrato WP in-process; **un** `tools/qa-*.sh` si cambió HTTP/admin/CLI |
 
 ---
 
@@ -59,13 +60,13 @@ recibir otra de mayor valor.**
 - **Rápido** — milisegundos en nivel 1; no arrancar WordPress/Docker salvo que el objetivo lo exija
 - **Legible** — nombres y variables de negocio explican por qué existe el test
 - **Específico** — al fallar, el escenario y la causa deben ser obvios
-- **Automatizado** — nivel 1 en CI; harnesses de nivel 2/3 deterministas y seguros en local
+- **Automatizado** — nivel 1 en CI; `composer test:wp` y harnesses de nivel 2/3 deterministas y seguros en local (Docker; no en el gate por defecto)
 - **Escribible** — el coste debe ser proporcionado; preferir cableado sociable a coreografía de mocks
 
 **Diferidas a tipos concretos:**
 
 - **Inspirador** — pasar debe dar confianza; los sociables lo logran con colaboradores internos reales
-- **Predictivo** — todo verde debe aproximar aptitud de producción; QA Docker aislado y contratos en fronteras WordPress
+- **Predictivo** — todo verde debe aproximar aptitud de producción; QA Docker aislado, `composer test:wp` y contratos en fronteras WordPress
 
 Validar comportamiento observable: reglas de negocio, errores, transiciones
 de estado, corrección de frontera, guards de publicación/capacidad/nonce
@@ -98,8 +99,10 @@ unitario puede incluir un helper del theme libre de WordPress
 theme, ni generar PDF de artículo en el theme (ADR 0017).
 
 No fingir APIs de WordPress cuando el objeto de la prueba **es** el
-comportamiento de WordPress. Eso es nivel 2/3: Docker aislado, WordPress 7.1
-real.
+comportamiento de WordPress. Eso es nivel 2: suite PHPUnit/WordPress
+(`tests/WordPress/`, `WP_UnitTestCase`) o un harness `tools/qa-*.sh`,
+ambos en Docker aislado contra WordPress 7.1 real. No Brain Monkey /
+WP_Mock.
 
 ### 1.1 Observación de frontera cambiada (upgrades de dependencia o adaptador)
 
@@ -141,14 +144,36 @@ Correspondencia con los tres niveles de `docs/23-testing-foundation.md`:
 | Este estándar | Nivel | Dónde vive |
 |---------------|-------|------------|
 | Programador sociable / solitario | Nivel 1 | `tests/Unit/`, PHPUnit, sin WordPress |
-| Integración estrecha | Nivel 2 | `tools/qa-*.sh` aislado (contratos WordPress) |
+| Integración estrecha | Nivel 2 | `tests/WordPress/` (wp-phpunit, `composer test:wp`) |
 | Contrato / aceptación | Nivel 3 | Gherkin en `tests/Features/` + `tools/qa-*.sh` |
-| Integración amplia | Nivel 2/3 | Harnesses Docker aislados; nunca producción |
+| Integración amplia | Nivel 2/3 | Harnesses Docker (`tools/qa-*.sh`) para HTTP / wp-admin / CLI; nunca producción |
 
-`tests/Integration/` y `composer test:integration` **aún no existen**. No
-inventar un bootstrap PHPUnit/WordPress para evitar un harness. No instalar
-Behat, Brain Monkey, WP_Mock, Mockery, Pest ni Playwright sin necesidad
-arquitectónica (ADR 0018).
+`tests/WordPress/` y `composer test:wp` **existen** desde 2026-08-28
+(autorización del propietario; ADR 0018 nota factual). Es el runner de
+nivel 2 in-process: framework `wp-phpunit/wp-phpunit` 7.1,
+`WP_UnitTestCase`, factories de posts, meta y taxonomías, tablas
+`wptests_`, Compose efímero (`tools/run-phpunit-wp.sh`). No existe
+`tests/Integration/` ni `composer test:integration` — no inventar un
+segundo bootstrap en paralelo.
+
+**Cuándo wp-phpunit y cuándo un harness**
+
+- **`tests/WordPress/` (por defecto para contratos WP in-process):**
+  mapeo post/meta/taxonomía → HTML o DTO; registro de CPT/taxonomía/rol;
+  adaptador o builder que llama APIs de WP; `render_callback` de un
+  bloque de dominio con posts de factory; un guard de publicación
+  invocable como PHP.
+- **`tools/qa-*.sh`:** petición HTTP, pantalla wp-admin, Media Library
+  picker, ajuste de opciones en el admin, comando WP-CLI del plugin tal
+  como lo corre un editor, flujo de varios pasos (bootstrap, teardown,
+  permalinks).
+- **No** reescribir un harness que ya cubre HTTP/admin a PHPUnit por
+  uniformidad. **No** usar un harness para evitar wp-phpunit cuando el
+  contrato es mapeo in-process.
+
+No instalar Behat, Brain Monkey, WP_Mock, Mockery, Pest ni Playwright
+sin necesidad arquitectónica (ADR 0018). `wp-phpunit` no es una de esas
+exclusiones: es el mecanismo de nivel 2.
 
 ### Sociable vs solitario
 
@@ -184,13 +209,17 @@ delegación u orden de llamadas.
 
 2. **Integración estrecha** (nivel 2)  
    Cableado, mapping, adaptadores, configuración y transformación de
-   entrada **en WordPress real**.  
+   entrada **en WordPress real**, in-process.  
+   Vive en `tests/WordPress/` y se corre con `composer test:wp` /
+   `./tools/run-phpunit-wp.sh`. Ejemplo vigente:
+   `ArticlePdfEditorialSourceBuilderTest`.  
    No llamar sistemas fuera de WordPress (host de producción, Crossref,
    ORCID, CDN).  
-   `docker compose -p <proyecto-efímero>` pertenece aquí, no como arranque
-   de cada unitario sociable.  
-   Excepción conocida: `tools/qa-author-permalinks.sh` usa volúmenes
-   primarios; no copiar ese patrón.
+   `docker compose -p <proyecto-efímero>` pertenece aquí (el runner WP
+   ya lo hace), no como arranque de cada unitario sociable.  
+   Los flujos HTTP/admin/CLI no son este tipo: van al harness
+   (`tools/qa-*.sh`). Excepción conocida: `tools/qa-author-permalinks.sh`
+   usa volúmenes primarios; no copiar ese patrón.
 
 3. **Pruebas solitarias** (restringidas, nivel 1)  
    Solo lógica pura con ramificación compleja donde el aislamiento aclara.  
@@ -207,8 +236,8 @@ delegación u orden de llamadas.
 
 4. **Tests de contrato**  
    Forma y semántica de la frontera.  
-   Gherkin enuncia el contrato de negocio en español. PHPUnit o un harness
-   lo ejecuta.  
+   Gherkin enuncia el contrato de negocio en español. PHPUnit nivel 1,
+   `composer test:wp` o un harness lo ejecuta.  
    No asertar detalles internos. No poner selectores CSS, nombres de clase,
    IDs de BD ni `sleep` en `.feature`.
 
@@ -379,7 +408,14 @@ cabe en clases planas.
 
 No arrancar WordPress dentro de `tests/Unit/`.
 
-- Proyecto compose aislado + `down -v` si el harness muta datos.
+Nivel 2 in-process: `tests/WordPress/` **solo** vía
+`./tools/run-phpunit-wp.sh` / `composer test:wp`. Ese runner levanta un
+Compose efímero (`revistalogos-wp-phpunit`, puerto 8090), instala tablas
+`wptests_` y hace `down -v` al salir. No apuntar `phpunit-wp.xml.dist`
+al volumen primario (`localhost:8080`) ni a producción.
+
+- Proyecto compose aislado + `down -v` si el harness o la suite WP muta
+  datos.
 - No reutilizar los volúmenes primarios (`localhost:8080`) en tests nuevos
   que mutan.
 - No apuntar harnesses a producción (`logo-et-spes.cenfiss.net`).
@@ -398,8 +434,10 @@ WP-CLI `eval`, sitio aislado).
 
 - Cada harness construye su propia URL (`http://localhost:<puerto-aislado>`).
 - Payloads en línea o vía WP-CLI; no depender de contenido residual.
-- No mezclar una llamada PHPUnit in-process y HTTP en vivo en el mismo
-  test de nivel 1 — no hay WordPress en nivel 1.
+- No mezclar una llamada PHPUnit in-process de nivel 1 y HTTP en vivo en el
+  mismo test — no hay WordPress en nivel 1. Los tests de
+  `tests/WordPress/` son in-process contra wp-phpunit; no hagan `curl`
+  al sitio primario.
 
 No instalar Supertest, Pest ni un cliente HTTP PHP para imitar NestJS.
 
@@ -415,7 +453,9 @@ Evitar factories globales, fixtures mutables compartidos y estado oculto.
 
 Factories y helpers compartidos al inicio del archivo (o en
 `tests/Support/`) solo si son puros, sin estado y devuelven valores
-frescos.
+frescos. En `tests/WordPress/`, `self::factory()->post->create()` y
+helpers de instancia que crean posts/meta **por test** están permitidos;
+no reutilizar IDs entre métodos.
 
 No deben:
 
@@ -484,18 +524,21 @@ agotar la máquina apilando QA Docker.
 | Regla | Requisito |
 |-------|-----------|
 | **Nivel 1 (gate por defecto)** | `composer test` o `./tools/run-phpunit.sh` — lint, audit del lockfile, suite unitaria completa. La suite es pequeña; correrla entera. |
-| **Nivel 2/3** | El `tools/qa-*.sh` **relevante** cuando cambió integración WordPress. Un harness a la vez. Cada uno debe hacer `down -v` y salir. |
-| **Prohibido** | BD de producción; volúmenes primarios en tests nuevos que mutan; todos los harnesses «por si acaso» en un cambio solo unitario; instalar runners extra por teatro de cobertura |
-| **CI** | `.github/workflows/test.yml` es lint + audit Composer (raíz y plugin) + `composer test:unit`. No corre `qa-*.sh`. No exigir Docker QA en un PR solo de docs o solo unitario. SonarQube Cloud es Automatic Analysis (`.sonarcloud.properties`); no es un gate de cobertura ni un paso de `test.yml`. |
+| **Nivel 2 in-process** | `composer test:wp` / `./tools/run-phpunit-wp.sh` cuando cambió un contrato WordPress que se ejercita en PHP (meta, CPT, builder, adaptador, `render_callback`). Requiere Docker. No entra en `composer test` ni en CI. |
+| **Nivel 2/3 HTTP** | El `tools/qa-*.sh` **relevante** cuando cambió HTTP, wp-admin o CLI. Un harness a la vez. Cada uno debe hacer `down -v` y salir. |
+| **Prohibido** | BD de producción; volúmenes primarios en tests nuevos que mutan; todos los harnesses «por si acaso» en un cambio solo unitario; usar un harness para evitar wp-phpunit en un mapeo in-process; instalar runners extra por teatro de cobertura |
+| **CI** | `.github/workflows/test.yml` es lint + audit Composer (raíz y plugin) + `composer test:unit`. No corre `composer test:wp` ni `qa-*.sh`. No exigir Docker QA en un PR solo de docs o solo unitario. SonarQube Cloud es Automatic Analysis (`.sonarcloud.properties`); no es un gate de cobertura ni un paso de `test.yml`. |
 
 Portátil sin PHP nativo: `./tools/php-lint.sh` y `./tools/run-phpunit.sh`
-(ADR 0014).
+(ADR 0014). `./tools/run-phpunit-wp.sh` requiere Docker (el portátil no
+necesita PHP nativo; sí el daemon).
 
 ---
 
 ## 10. Nombres (contexto de negocio obligatorio)
 
-Seguir el nombrado WordPress PHP de `includes/` y `tests/Unit/`:
+Seguir el nombrado WordPress PHP de `includes/`, `tests/Unit/` y
+`tests/WordPress/`:
 
 - Clases de test: `PascalCase` + sufijo `Test` (`ArticlePdfPublicationPolicyTest`)
 - Métodos: `test_` + `snake_case` de comportamiento
@@ -586,7 +629,7 @@ Reglas:
 - No mockear la clase bajo prueba
 - No mockear value objects
 - No mockear cada función de WordPress; si el comportamiento es WordPress,
-  usar un harness
+  usar `tests/WordPress/` (wp-phpunit) o un harness `tools/qa-*.sh`
 - No extender una clase de producción solo para anular un método, salvo
   que esa clase sea la costura documentada y aún no exista interfaz
 
@@ -671,17 +714,20 @@ Los comandos, el alcance de CI y la lista de harnesses están en
 [23-testing-foundation](23-testing-foundation.md). Resumen:
 
 ```bash
-composer test              # lint → audit --locked → units; no qa-*.sh
+composer test              # lint → audit --locked → units; no test:wp ni qa-*.sh
 composer test:unit
+composer test:wp           # PHPUnit/WordPress aislado (Docker); no CI
 ./tools/php-lint.sh
 ./tools/run-phpunit.sh
+./tools/run-phpunit-wp.sh
 ```
 
 `php -l` comprueba **sintaxis**. `composer audit --locked` comprueba
-**advisories del lockfile**. PHPUnit comprueba **comportamiento**.
-`qa-*.sh` comprueba **WordPress integrado**.
+**advisories del lockfile**. PHPUnit nivel 1 comprueba **comportamiento
+puro**. `composer test:wp` comprueba **contratos WordPress in-process**.
+`qa-*.sh` comprueba **flujos HTTP / wp-admin / CLI**.
 
 ---
 
-**Versión:** 1.1
+**Versión:** 1.2
 **Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0

--- a/docs/24-project-testing-standard.md
+++ b/docs/24-project-testing-standard.md
@@ -434,10 +434,11 @@ WP-CLI `eval`, sitio aislado).
 
 - Cada harness construye su propia URL (`http://localhost:<puerto-aislado>`).
 - Payloads en línea o vía WP-CLI; no depender de contenido residual.
-- No mezclar una llamada PHPUnit in-process de nivel 1 y HTTP en vivo en el
-  mismo test — no hay WordPress en nivel 1. Los tests de
-  `tests/WordPress/` son in-process contra wp-phpunit; no hagan `curl`
-  al sitio primario.
+- No mezclar una llamada PHP in-process y una petición HTTP en vivo dentro
+  del mismo test. En nivel 1 no hay WordPress que llamar; en
+  `tests/WordPress/` sí lo hay —wp-phpunit, **también** in-process— y aun
+  así ese test no debe hacer `curl` al sitio primario. Lo in-process no
+  distingue un nivel de otro: lo que es del harness es el HTTP en vivo.
 
 No instalar Supertest, Pest ni un cliente HTTP PHP para imitar NestJS.
 

--- a/docs/24-project-testing-standard.md
+++ b/docs/24-project-testing-standard.md
@@ -730,4 +730,4 @@ puro**. `composer test:wp` comprueba **contratos WordPress in-process**.
 ---
 
 **Versión:** 1.2
-**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,4 +77,4 @@ Ningún documento puede depender de uno con número mayor. Ver `00-order-documen
 ---
 
 **Versión:** 1.6
-**Proyecto:** Revista de Filosofía LOGO ET SPES 0.2.0
+**Proyecto:** Revista de Filosofía LOGO ET SPES

--- a/docs/adr/0018-testing-foundation.md
+++ b/docs/adr/0018-testing-foundation.md
@@ -31,22 +31,27 @@ local 7.1.
    No entra en el plugin ni en el theme. El FTPS (ADR 0009) no sube `vendor/`
    ni `tests/`. El plugin sigue sin autoload Composer (ADR 0006 / 0005).
 3. **Tres niveles:** unitario (PHPUnit, sin WordPress ni DB); integración
-   WordPress (hoy: harnesses Docker aislados; PHPUnit+WP aplazado); aceptación
-   (`tools/qa-*.sh`).
+   WordPress in-process (suite PHPUnit/WordPress con `wp-phpunit` 7.1 en
+   Docker aislado: `tests/WordPress/`, `composer test:wp`) más harnesses
+   `tools/qa-*.sh` para HTTP / wp-admin / CLI; aceptación (`tools/qa-*.sh`
+   para flujos completos). No fingir APIs de WordPress (Brain Monkey /
+   WP_Mock). La suite WP no entra en `composer test` ni en CI: requiere
+   Docker, igual que los harnesses.
 4. **Gherkin** vive en `tests/Features/`. Especifica comportamiento de
    negocio. **Behat no se instala** hasta que haya escenarios suficientes.
 5. **TDD** es obligatorio para comportamiento de dominio nuevo (ADR 0017 y
    siguientes). Las reglas operativas están en `docs/23-testing-foundation.md`.
-6. **Fuente durable de testing:** este ADR, `docs/23-testing-foundation.md` y
-   el resumen en `CLAUDE.md`. `.cursor/` está gitignored a propósito; reglas
-   Cursor locales, si existen, no son autoridad ni requisito.
+6. **Fuente durable de testing:** este ADR, `docs/23-testing-foundation.md`,
+   `docs/24-project-testing-standard.md` y el resumen en `CLAUDE.md`.
+   `.cursor/` está gitignored a propósito; reglas Cursor locales, si
+   existen, no son autoridad ni requisito.
 
 ## Alternativas consideradas
 
 | Alternativa | Motivo de descarte |
 | ----------- | ------------------ |
 | PHPUnit 10/11 (solo PHP 8.1+/8.2+) | Impide ejecutar el runner en el mínimo declarado 7.4; 9.6 cubre 7.4 y 8.2. |
-| WordPress Core test suite / wp-env / wp-browser en esta unidad | Duplica el Docker aislado que ya prueba WP 7.1; coste desproporcionado para el primer incremento. |
+| WordPress Core test suite / wp-env / wp-browser **en el primer incremento** (2026-08-20) | Duplicaba el Docker aislado que ya probaba WP 7.1; coste desproporcionado entonces. El incremento 2026-08-28 instaló `wp-phpunit` (no wp-env ni wp-browser) como runner de nivel 2 in-process. |
 | Behat ahora | Ceremonial: pocos escenarios; YAGNI. |
 | Brain Monkey / WP_Mock / Pest / Mockery | No hacen falta para el seam unitario actual; mocks masivos de WP se evitan. |
 | Solo harnesses shell | Insuficiente para TDD de políticas puras (ADR 0017). |
@@ -58,12 +63,14 @@ local 7.1.
 sin secretos ni producción; el plugin desplegado no cambia.
 
 **Riesgos / costes:** Composer en raíz hay que no copiarlo al plugin;
-integración PHPUnit/WP queda como incremento; D12b (auditoría de
-automatización de seguridad) **no** se cierra con este ADR.
+la suite PHPUnit/WP y los harnesses requieren Docker local y no corren
+en el workflow `test.yml`; D12b (auditoría de automatización de
+seguridad) **no** se cierra con este ADR.
 
-**Trabajo futuro:** suite PHPUnit de integración WordPress 7.1 en Docker
-aislado cuando un contrato WP no quepa en un harness; runner Gherkin si el
-volumen de `.feature` lo justifica; matriz PHP 7.4/8.0 solo si aporta.
+**Trabajo futuro:** runner Gherkin si el volumen de `.feature` lo
+justifica; matriz PHP 7.4/8.x o WordPress en CI solo si aporta; no
+añadir Behat, Brain Monkey, wp-env ni Playwright sin necesidad
+arquitectónica.
 
 ## Estado de implementación (2026-08-20)
 
@@ -88,6 +95,18 @@ Nota factual 2026-08-24 (no cambia §1–§6): el oficio de cómo escribir un
 test vive en `docs/24-project-testing-standard.md`. Complementa `docs/23`
 (taxonomía, CI, comandos). No añade runners ni cambia PHPUnit 9.6, Gherkin
 sin Behat, ni la exclusión de Brain Monkey / Mockery / Pest.
+
+Nota factual 2026-08-28 (no cambia §1–§2 ni §4–§5; **§3 queda alineada
+con esta nota**): el propietario autorizó instalar la suite
+PHPUnit/WordPress para el diseño editorial del PDF (issue #10).
+Implementación: `wp-phpunit/wp-phpunit` 7.1 + `yoast/phpunit-polyfills`
+en el Composer de raíz, `phpunit-wp.xml.dist`, `tests/WordPress/`,
+`tools/run-phpunit-wp.sh` / `composer test:wp`, Compose efímero puerto
+8090, tablas `wptests_`, `down -v` al salir. Primer contrato:
+`ArticlePdfEditorialSourceBuilderTest`. No entra en `composer test` ni
+en CI. No se instaló Behat, Brain Monkey, WP_Mock, Mockery, Pest,
+wp-env ni wp-browser. El texto original de §3 («PHPUnit+WP aplazado»)
+deja de ser el estado vigente.
 
 Nota factual 2026-08-28 (no cambia §1–§6): SonarQube Cloud está
 conectado por GitHub App (**Automatic Analysis**, proyecto

--- a/docs/operations/wordpress-manual-deployment.md
+++ b/docs/operations/wordpress-manual-deployment.md
@@ -160,20 +160,33 @@ históricos. Desde 2026-08-20 el workflow usa `checkout@v5` y
    Nunca despachar desde una etiqueta anterior a lo que producción ya
    sirve: reinstalaría una versión más vieja.
 
-   **Verificar además que la etiqueta es lo que dice ser.** El gate
-   comprueba que *exista* una etiqueta anotada `vX.Y.Z` en HEAD, **no** que
-   su contenido corresponda a esa versión: una etiqueta bien formada sobre
-   el commit equivocado pasa el gate y despliega código equivocado en
-   silencio (ocurrido el 2026-08-29 con `v0.3.0`, colocada sobre una rama
-   de CI que llevaba el plugin 0.2.8 ya live). Comprobar las tres cosas:
+   **Verificar además que la etiqueta es lo que dice ser.** Hasta el
+   2026-08-29 el gate comprobaba que *exista* una etiqueta anotada `vX.Y.Z`
+   en HEAD, no que su contenido correspondiera a esa versión: una etiqueta
+   bien formada sobre el commit equivocado pasaba y habría desplegado
+   código equivocado en silencio (ocurrido ese mismo día con `v0.3.0`,
+   colocada sobre una rama de CI que llevaba el plugin 0.2.8 ya live). El
+   gate ya lo verifica —versión declarada en `package.json` y commit
+   alcanzable desde `main`—, pero llegar hasta él con la etiqueta mal
+   puesta significa que ya está publicada, y corregirla obliga a borrarla y
+   recrearla en local y en el remoto. Comprobarlo aquí sale más barato.
+
+   Traer primero las refs: `origin/main` y las etiquetas locales pueden
+   estar viejas, y entonces se estaría validando un commit que no es el
+   real.
 
    ```bash
-   git merge-base --is-ancestor vX.Y.Z origin/main && echo "en main"
+   git fetch --tags origin main
+   git merge-base --is-ancestor vX.Y.Z origin/main && echo "en main" || { echo "NO está en main"; false; }
    git show vX.Y.Z:package.json | grep '"version"'
    git show vX.Y.Z:wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php | grep REVISTALOGOS_CORE_VERSION
    ```
 
-   La versión del plugin debe ser **mayor** que la que corre producción.
+   La comprobación de `main` imprime el caso negativo y deja `rc != 0`: sin
+   eso, un fallo no dice nada y se pasa por alto leyendo la lista.
+
+   La versión del plugin debe ser **mayor** que la que corre producción —
+   eso el gate no puede saberlo, y sigue siendo comprobación humana.
 2. **Commit y rama:** `git rev-parse HEAD` y la etiqueta (`git describe --exact-match --tags`).
    Working tree limpio (`git status --short`).
 3. **Cambios incluidos:** solo theme y/o plugin first-party. Sin fixtures,

--- a/docs/operations/wordpress-manual-deployment.md
+++ b/docs/operations/wordpress-manual-deployment.md
@@ -157,7 +157,23 @@ históricos. Desde 2026-08-20 el workflow usa `checkout@v5` y
    debe pasar. Si falla, no hay deploy: bump de `package.json` /
    `VERSION.md` / `CHANGELOG.md`, PR `chore(release): vX.Y.Z`, etiqueta
    anotada, y Run workflow **desde esa tag**. Merge a `main` no basta.
-   No despachar desde `v0.2.0` (producción ya sirve plugin 0.2.8).
+   Nunca despachar desde una etiqueta anterior a lo que producción ya
+   sirve: reinstalaría una versión más vieja.
+
+   **Verificar además que la etiqueta es lo que dice ser.** El gate
+   comprueba que *exista* una etiqueta anotada `vX.Y.Z` en HEAD, **no** que
+   su contenido corresponda a esa versión: una etiqueta bien formada sobre
+   el commit equivocado pasa el gate y despliega código equivocado en
+   silencio (ocurrido el 2026-08-29 con `v0.3.0`, colocada sobre una rama
+   de CI que llevaba el plugin 0.2.8 ya live). Comprobar las tres cosas:
+
+   ```bash
+   git merge-base --is-ancestor vX.Y.Z origin/main && echo "en main"
+   git show vX.Y.Z:package.json | grep '"version"'
+   git show vX.Y.Z:wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php | grep REVISTALOGOS_CORE_VERSION
+   ```
+
+   La versión del plugin debe ser **mayor** que la que corre producción.
 2. **Commit y rama:** `git rev-parse HEAD` y la etiqueta (`git describe --exact-match --tags`).
    Working tree limpio (`git status --short`).
 3. **Cambios incluidos:** solo theme y/o plugin first-party. Sin fixtures,

--- a/tests/Features/README.md
+++ b/tests/Features/README.md
@@ -3,9 +3,10 @@
 Canonical location for `.feature` files: this directory.
 
 Gherkin here is a **versioned business specification**, not an executable
-Behat suite. PHPUnit verifies PHP behavior; isolated `tools/qa-*.sh`
-harnesses verify integrated WordPress workflows. Do not install Behat
-until there are enough scenarios to justify a runner.
+Behat suite. PHPUnit level 1 verifies pure PHP; `composer test:wp`
+(`tests/WordPress/`) verifies in-process WordPress contracts; isolated
+`tools/qa-*.sh` harnesses verify HTTP / wp-admin / CLI. Do not install
+Behat until there are enough scenarios to justify a runner.
 
 Language: **Spanish** (same as `docs/`). Do not mix English and Spanish
 inside one feature.
@@ -13,6 +14,10 @@ inside one feature.
 Write observable business behavior, not class or method names. Rules:
 `docs/23-testing-foundation.md` (stack, CI, Gherkin location) and
 `docs/24-project-testing-standard.md` (how to write a test).
+
+PHPUnit level 1, the WordPress suite, and the harnesses may each
+execute part of a feature. There is no required 1:1 trace. Do not
+install Behat until there are enough scenarios to justify a runner.
 
 ADR 0017 lives in `article-pdf-generation.feature` (business
 specification only; no Behat). Scenarios cover enforcement OFF

--- a/tests/Features/README.md
+++ b/tests/Features/README.md
@@ -16,8 +16,7 @@ Write observable business behavior, not class or method names. Rules:
 `docs/24-project-testing-standard.md` (how to write a test).
 
 PHPUnit level 1, the WordPress suite, and the harnesses may each
-execute part of a feature. There is no required 1:1 trace. Do not
-install Behat until there are enough scenarios to justify a runner.
+execute part of a feature. There is no required 1:1 trace.
 
 ADR 0017 lives in `article-pdf-generation.feature` (business
 specification only; no Behat). Scenarios cover enforcement OFF


### PR DESCRIPTION
## Por qué

Dos huecos independientes, el mismo patrón: la documentación se quedó
describiendo un estado que `main` ya había dejado atrás. Quien la siguiera al
pie de la letra haría lo incorrecto, sin ningún síntoma que lo delatara.

---

## Parte 1 — El release etiquetado y su trampa

El README decía solo esto sobre producción:

> **Producción WordPress:** `https://logo-et-spes.cenfiss.net`. Solo `deploy-wordpress.yml` (manual). No hay staging WordPress.

Quien no abriera el runbook no tenía forma de saber que producción sale de un **release etiquetado**, ni cómo lanzarlo. El runbook sí lo explicaba bien; el problema era que nada lo llevaba hasta ahí.

Y ninguno de los dos recogía el fallo realmente peligroso: **el gate comprobaba que *exista* una etiqueta anotada `vX.Y.Z` en HEAD, no que su contenido correspondiera a esa versión.**

No es hipotético. Ocurrió el **2026-08-29**: `v0.3.0` quedó colocada sobre una rama de CI que llevaba

| | en la etiqueta | correcto |
|---|---|---|
| proyecto | 0.2.0 | 0.3.0 |
| plugin | **0.2.8** ← ya en producción | 0.2.9 |

`tools/require-production-release-tag.sh` devolvía **rc=0** sobre esa etiqueta. El despliegue solo se evitó porque se lanzó desde `main`, que el gate sí rechaza; **desde `Tags → v0.3.0` habría pasado y habría reinstalado el plugin viejo sobre producción sin ningún aviso.**

### El agujero ya está cerrado — y eso cambia lo que toca escribir

#26 se mergeó mientras este PR estaba en draft, así que el gate **ya verifica el contenido de la etiqueta**: versión declarada en `package.json` y commit alcanzable desde `main`. El texto que aquí se proponía describía un agujero recién tapado.

Reescrito en pasado, conservando el motivo por el que las comprobaciones manuales siguen mereciendo la pena:

- el gate falla cuando la etiqueta **ya está publicada** y el run despachado, y deshacer eso obliga a borrarla y recrearla en local y en el remoto;
- hay algo que el gate no puede saber —**qué versión de plugin corre producción ahora mismo**— y que sigue siendo comprobación humana.

### Cambios

**`README.md`** — la sección de producción pasa de tres líneas a las dos reglas de ADR 0020 (mergear no despliega; elegir `Tags → vX.Y.Z`, nunca `main`), el procedimiento de release resumido, y el aviso sobre la etiqueta engañosa con los comandos para verificarla. Además la cabecera decía **0.2.0** cuando `package.json` ya declara 0.3.0.

**`VERSION.md`** — el paso 6 pasa a etiquetar explícitamente sobre `origin/main`, y se sustituye la nota ya obsoleta «no despachar desde `v0.2.0`» por la regla general.

**`docs/operations/wordpress-manual-deployment.md`** — la verificación de la etiqueta entra en PRE-DESPLIEGUE con los comandos concretos, integrada en el punto 1 para **no renumerar** la lista y romper referencias.

De paso, `Lint CSS` documenta `nvm use` — `engines` pide `node >=20.19.0` por stylelint 17 y con menos npm avisa `EBADENGINE`.

### Revisión atendida

Los dos comentarios *blocking* de Copilot eran correctos:

- **Faltaba `git fetch` antes de usar `origin/main`.** Es una referencia local: si está vieja, se etiqueta un commit anterior al release, o se valida uno que no es el real — exactamente el fallo que la sección documenta. Se añade `git fetch --tags origin main` antes de etiquetar (README, `VERSION.md`) y antes de verificar (runbook).
- **`git merge-base --is-ancestor` no imprime nada al fallar**, así que un negativo se pasa por alto leyendo la lista. En el runbook pasa a imprimir el caso negativo conservando `rc != 0`.

Y una incoherencia que #26 acababa de crear: «subir la cabecera `Version` del theme o del plugin» describe al theme, no al plugin, cuya versión vive en la constante `REVISTALOGOS_CORE_VERSION`. Corregido en el README y en el paso 4 de `VERSION.md`.

### Tercera ronda: dónde declara su versión cada componente

Aceptadas tres observaciones más, y la corrección de fondo era **mía**. El plugin declara su versión en **tres** sitios, no en uno:

| Dónde | Quién la lee |
|---|---|
| `Version:` en `revistalogos-core.php` | wp-admin → Plugins |
| `REVISTALOGOS_CORE_VERSION` en ese mismo archivo | `Plugin::maybe_upgrade()` |
| `Stable tag:` en `readme.txt` | metadatos del plugin |

Y el theme **no** tiene `Stable tag:` ni `readme.txt`: solo `Version:` en `style.css`. Lo que decían estos documentos era falso en las dos direcciones — mandaban buscar un campo inexistente en el theme y negaban una cabecera que el plugin sí tiene. Como la imprecisión venía arrastrada de #26, se corrige también en `CLAUDE.md`, donde ya está en `main`.

Importa por qué son tres: si divergen, wp-admin informa de una versión que **no** es la que decide si el upgrade corre — y `tools/check-release-pending.sh` solo lee la constante, así que una cabecera desincronizada no la avisa nadie. Queda anotado ese punto ciego.

Tercera: el comando del README conservaba `|| echo …`, que imprime el caso negativo pero devuelve `rc=0` — el mismo fallo ya corregido en el runbook. Los dos documentos usan ahora la misma forma.

### Cuarta ronda: los pies de `docs/` dejan de repetir la versión

Los dos comentarios sobre el pie «Proyecto 0.2.0» de `docs/23` y `docs/24` señalaban un desajuste real, pero la corrección obvia era la equivocada. **Siete** documentos llevaban ese número y los siete decían 0.2.0; los otros diecinueve pies nunca lo llevaron. Subir solo dos habría cambiado una inconsistencia uniforme por una divergente.

Y subir los siete tampoco resolvía nada: ningún paso del procedimiento de publicación de `VERSION.md` toca esos pies, así que volverían a desfasarse en el siguiente release exactamente igual que se desfasaron en este.

Decisión del propietario: **quitar el número**. Los 26 pies quedan uniformes como `**Proyecto:** Revista de Filosofía LOGO ET SPES`, y la versión vive solo donde `VERSION.md` la declara canónica. Añadida la regla a `VERSION.md` § Fuente de verdad, aclarando además algo que estaba a medias: el `**Versión:**` que va justo encima es la revisión **del propio documento**, no la del proyecto, y sigue evolucionando aparte.

*(En las respuestas del hilo dije «8 documentos». Son 7: 26 pies en total, 7 con número y 19 sin él. Corregido también en el propio hilo.)*

---

## Parte 2 — El nivel 2 de testing existe, y la documentación decía que no

`tests/WordPress/`, `phpunit-wp.xml.dist`, `tools/run-phpunit-wp.sh` y `composer test:wp` están en `main` **desde el 2026-08-28**. La documentación seguía diciendo «PHPUnit+WP aplazado» y mandaba *todo* contrato de WordPress a un harness `tools/qa-*.sh`.

El coste de dejarlo así no es cosmético: quien siguiera el estándar escribiría un harness HTTP —Docker, puerto propio, `down -v`, minutos por ejecución— para verificar un mapeo in-process que `wp-phpunit` ya cubre en segundos.

### Cambios

**`docs/adr/0018-testing-foundation.md`** — §3 alineada con la nota factual del 2026-08-28: qué se instaló exactamente (`wp-phpunit/wp-phpunit` 7.1 + `yoast/phpunit-polyfills`) y, sobre todo, **qué no** (ni Behat, ni Brain Monkey, ni WP_Mock, ni wp-env, ni wp-browser: esas exclusiones siguen vigentes). §6 incorpora `docs/24` como fuente durable.

**`docs/23-testing-foundation.md`** — criterio de reparto dentro del nivel 2 y comandos actualizados.

**`docs/24-project-testing-standard.md`** — alcance, tabla de niveles, aislamiento (Compose efímero `revistalogos-wp-phpunit`, puerto 8090, tablas `wptests_`, `down -v` al salir), factories permitidas por test, y la regla que faltaba en ambas direcciones:

- **No** reescribir a PHPUnit un harness que ya cubre HTTP/wp-admin/CLI por uniformidad.
- **No** usar un harness para esquivar `wp-phpunit` cuando el contrato es un mapeo in-process.

**`CLAUDE.md`** y **`tests/Features/README.md`** — el mismo reparto, sin cambiar qué corre `composer test` (sigue **sin** `test:wp`) ni qué corre CI.

`composer test:wp` requiere Docker y no entra en `composer test` ni en `test.yml`. Eso no cambia aquí.

---

## Verificación

Los comandos que documenta la Parte 1, ejecutados de verdad:

```
"version": "0.3.0"
define( 'REVISTALOGOS_CORE_VERSION', '0.2.9' );
en main ✅
```

- `git fetch --tags origin main` **sí** actualiza `refs/remotes/origin/main`: comprobado en un clon con la ref forzada tres commits atrás, que vuelve a la punta real tras el fetch.
- La comprobación de `main` imprime y propaga el fallo: `en main` / rc=0 en el caso positivo, `NO está en main` / **rc=1** en el negativo.
- Numeración de PRE-DESPLIEGUE: sigue **1–9 sin saltos** (mi primer intento usó un marcador `1b.`, que Markdown no reconoce y habría roto la lista).

La Parte 2 no describe trabajo nuevo: cada afirmación se contrasta con lo que ya está en `main` (`composer.json` declara `test:wp`; los cuatro archivos de la suite existen; el primer contrato es `ArticlePdfEditorialSourceBuilderTest`).

Rama rebasada sobre `main` con #26 ya dentro (`763f401`); sin conflictos.

## Nota de alcance

Este PR **no toca código**: son cinco documentos y dos ficheros de referencia. Endurecer `tools/require-production-release-tag.sh` para que compruebe el *contenido* de la etiqueta vivía en #26, **ya mergeado**; este PR se limita a que la documentación deje de contradecirlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



