### PR TITLE
ci(labels): etiquetar PRs e issues automáticamente (ADR 0019 §7)

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,126 @@
+# Etiquetado automático de PRs e issues (ADR 0019 §7).
+#
+# Existe porque la etiqueta es otro de esos pasos que nadie está obligado a
+# recordar: de los 21 primeros PRs solo tres humanos llevaban una, y dos la
+# llevaban mal. Documentar la regla no habría bastado — es exactamente el
+# fallo que ya se repitió con el release etiquetado (ADR 0020).
+#
+# Dos trabajos independientes:
+#
+#   1. PR abierto, reabierto, retitulado o sacado de draft -> se deriva
+#      `type: <tipo>` del prefijo Conventional Commits del título y se
+#      retiran las demás `type: *`. El título ya es obligatorio y ya está
+#      normalizado (ADR 0019 §4), así que no hay criterio nuevo que aplicar
+#      ni juicio que delegar en quien abre el PR.
+#
+#   2. Issue cerrado -> se retiran `next` / `planned` / `deferred`. Son
+#      estado de backlog, no historia: un issue resuelto que conserva
+#      `next` miente sobre lo que queda por hacer (pasó con #9).
+#
+# Solo toca esas dos familias. Las demás etiquetas —los defaults de GitHub
+# (`documentation`, `bug`, `enhancement`, `help wanted`…) y las de
+# Dependabot— son un eje aparte que se pone a mano y que este workflow no
+# añade ni retira nunca: un PR lleva las que hagan falta (ADR 0019 §7).
+#
+# No usa acciones de terceros ni secretos: `gh` viene en el runner y
+# `github.token` basta. Nunca hace checkout del código del PR, así que
+# `pull_request_target` no ejecuta nada que venga de la rama.
+name: Labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, ready_for_review]
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: labels-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-type:
+    name: Etiquetar el PR según su título
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Derivar type:* del prefijo Conventional Commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -uo pipefail
+
+          # feat(scope)!: asunto  ->  feat
+          TYPE="$(printf '%s' "$TITLE" \
+            | sed -n -E 's/^([a-z]+)(\([^)]*\))?!?:[[:space:]].*/\1/p')"
+
+          case "$TYPE" in
+            feat|fix|docs|chore|refactor|ci|test|perf|revert) ;;
+            *)
+              echo "::warning::El título del PR #${NUMBER} no empieza por un tipo Conventional Commits válido, así que no hay etiqueta que derivar (ADR 0019 §4)."
+              echo "  título: ${TITLE}"
+              echo "  tipos:  feat fix docs chore refactor ci test perf revert"
+              exit 0
+              ;;
+          esac
+
+          WANTED="type: ${TYPE}"
+          echo "Título: ${TITLE}"
+          echo "Tipo derivado: ${WANTED}"
+
+          CURRENT="$(gh pr view "$NUMBER" --repo "$REPO" --json labels \
+            --jq '.labels[].name | select(startswith("type: "))')"
+
+          # Un PR es de un tipo. Las que sobran se quitan aunque la correcta
+          # ya esté: un retitulado de docs: a fix: no debe dejar las dos.
+          while IFS= read -r label; do
+            [[ -n "$label" && "$label" != "$WANTED" ]] || continue
+            echo "Quitando ${label}"
+            gh pr edit "$NUMBER" --repo "$REPO" --remove-label "$label"
+          done <<<"$CURRENT"
+
+          if grep -qxF "$WANTED" <<<"$CURRENT"; then
+            echo "Ya lleva ${WANTED}; nada que hacer."
+            exit 0
+          fi
+
+          gh pr edit "$NUMBER" --repo "$REPO" --add-label "$WANTED"
+          echo "Aplicada ${WANTED}"
+
+  issue-closed:
+    name: Retirar el estado de backlog al cerrar
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Quitar next / planned / deferred
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -uo pipefail
+
+          CURRENT="$(gh issue view "$NUMBER" --repo "$REPO" --json labels \
+            --jq '.labels[].name | select(. == "next" or . == "planned" or . == "deferred")')"
+
+          if [[ -z "$CURRENT" ]]; then
+            echo "El issue #${NUMBER} no llevaba estado de backlog; nada que retirar."
+            exit 0
+          fi
+
+          while IFS= read -r label; do
+            [[ -n "$label" ]] || continue
+            echo "Quitando ${label} del issue cerrado #${NUMBER}"
+            gh issue edit "$NUMBER" --repo "$REPO" --remove-label "$label"
+          done <<<"$CURRENT"
+
+          echo "Recordatorio: mover también su entrada en docs/adr/BACKLOG.md (ADR 0019 §7)."

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -55,24 +55,36 @@ jobs:
           NUMBER: ${{ github.event.pull_request.number }}
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
+
+          # Un título es una línea. Con uno multilínea, un `sed` anclado en ^
+          # derivaría el tipo de la segunda línea, y un `echo` del título
+          # inyectaría líneas sueltas en el log del job —incluidos pseudo
+          # comandos de workflow como ::error:: o ::stop-commands::—, que en
+          # `pull_request_target` viene de quien abrió el PR. Se recorta a la
+          # primera línea y se acota antes de usarlo o imprimirlo. Con
+          # expansión de parámetros, no con tuberías: `head` cerraría el pipe
+          # y `pipefail` convertiría el SIGPIPE en un fallo del step.
+          FIRST_LINE="${TITLE%%$'\n'*}"
+          FIRST_LINE="${FIRST_LINE%$'\r'}"
+          SAFE_TITLE="${FIRST_LINE:0:200}"
 
           # feat(scope)!: asunto  ->  feat
-          TYPE="$(printf '%s' "$TITLE" \
+          TYPE="$(printf '%s' "$FIRST_LINE" \
             | sed -n -E 's/^([a-z]+)(\([^)]*\))?!?:[[:space:]].*/\1/p')"
 
           case "$TYPE" in
             feat|fix|docs|chore|refactor|ci|test|perf|revert) ;;
             *)
               echo "::warning::El título del PR #${NUMBER} no empieza por un tipo Conventional Commits válido, así que no hay etiqueta que derivar (ADR 0019 §4)."
-              echo "  título: ${TITLE}"
+              echo "  título: ${SAFE_TITLE}"
               echo "  tipos:  feat fix docs chore refactor ci test perf revert"
               exit 0
               ;;
           esac
 
           WANTED="type: ${TYPE}"
-          echo "Título: ${TITLE}"
+          echo "Título: ${SAFE_TITLE}"
           echo "Tipo derivado: ${WANTED}"
 
           CURRENT="$(gh pr view "$NUMBER" --repo "$REPO" --json labels \
@@ -107,7 +119,7 @@ jobs:
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
 
           CURRENT="$(gh issue view "$NUMBER" --repo "$REPO" --json labels \
             --jq '.labels[].name | select(. == "next" or . == "planned" or . == "deferred")')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 ## [Sin publicar]
 
 ### Added
+- Política de etiquetas de issues y PRs (ADR 0019 §7): tres ejes que
+  conviven —`type: *` derivada del prefijo Conventional Commits del título
+  (obligatoria, una), `next`/`planned`/`deferred` solo en issues, y los
+  defaults de GitHub como eje complementario opcional. Workflow `Labels`
+  (`.github/workflows/labels.yml`) que deriva `type: *` al abrir, reabrir,
+  retitular o sacar de draft un PR y retira el estado de backlog al cerrar
+  un issue; sin secretos, sin acciones de terceros y sin checkout del código
+  del PR. Advisory: no bloquea el merge.
+
+### Added
 - SonarQube Cloud Automatic Analysis scope: `.sonarcloud.properties`
   (plugin `revistalogos-core` + theme `revistalogos`; `tests/` as tests).
   Not `sonar-project.properties` (ignored while Automatic Analysis is ON).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,6 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 ## [Sin publicar]
 
 ### Added
-- Política de etiquetas de issues y PRs (ADR 0019 §7): tres ejes que
-  conviven —`type: *` derivada del prefijo Conventional Commits del título
-  (obligatoria, una), `next`/`planned`/`deferred` solo en issues, y los
-  defaults de GitHub como eje complementario opcional. Workflow `Labels`
-  (`.github/workflows/labels.yml`) que deriva `type: *` al abrir, reabrir,
-  retitular o sacar de draft un PR y retira el estado de backlog al cerrar
-  un issue; sin secretos, sin acciones de terceros y sin checkout del código
-  del PR. Advisory: no bloquea el merge.
-
-### Added
 - SonarQube Cloud Automatic Analysis scope: `.sonarcloud.properties`
   (plugin `revistalogos-core` + theme `revistalogos`; `tests/` as tests).
   Not `sonar-project.properties` (ignored while Automatic Analysis is ON).
@@ -30,6 +20,15 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
   declara (constante `REVISTALOGOS_CORE_VERSION` en el plugin, cabecera
   `Version:` en el theme). Advisory: no bloquea merges, no usa secretos y no
   despliega.
+- Política de etiquetas de issues y PRs (ADR 0019 §7): tres ejes que
+  conviven —`type: *` derivada del prefijo Conventional Commits del título
+  (obligatoria, una), `next`/`planned`/`deferred` solo en issues, y los
+  defaults de GitHub como eje complementario opcional. Workflow `Labels`
+  (`.github/workflows/labels.yml`) que deriva `type: *` al abrir, reabrir,
+  retitular o sacar de draft un PR y retira el estado de backlog al cerrar
+  un issue; sin secretos, sin acciones de terceros y sin checkout del código
+  del PR. Advisory: no bloquea el merge.
+
 
 ### Changed
 - Los pies de `docs/` dejan de repetir la versión del proyecto. Siete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,26 +157,39 @@ required, not shared via Git, not a substitute for the files above.
 - Small, reviewable commits per work unit (see the WU table in
   `docs/fase3-execution-state.md`), not one large commit spanning several.
 - **Merging a feature does not finish it.** A work unit is closed only when
-  all four are true, and they are easy to forget once the PR goes green:
-  (1) `docs/fase3-execution-state.md` updated; (2) the GitHub issue closed
-  **and** its `next`/`planned`/`deferred` label removed, plus its
-  `docs/adr/BACKLOG.md` entry moved out of the pending section; (3) an entry
-  under `## [Sin publicar]` in `CHANGELOG.md`; (4) if it touched
+  all four are true, and they are easy to forget once the PR goes green: (1)
+  `docs/fase3-execution-state.md` updated; (2) the GitHub issue closed (the
+  `Labels` workflow strips its `next`/`planned`/`deferred` label on close —
+  verify it did) **and** its `docs/adr/BACKLOG.md` entry moved out of the
+  pending section, which nothing automates; (3) an entry under
+  `## [Sin publicar]` in `CHANGELOG.md`; (4) if it touched
   `wordpress/wp-content/themes/` or `.../plugins/`, **bump the version that
   component declares, in the same PR** — the theme only in `Version:` of
   `style.css`; the plugin in three places that must stay identical: the
   `Version:` header and `REVISTALOGOS_CORE_VERSION` in
   `revistalogos-core.php`, plus `Stable tag:` in its `readme.txt`
   (`maybe_upgrade()` compares the constant, wp-admin shows the header, and
-  `check-release-pending.sh` only reads the constant) — shipping changed code under a
-  version string already live in production means `Plugin::maybe_upgrade()`
-  never fires. Flag any of these that is missing instead of assuming the owner
-  will remember. Only (4) is automated: `tools/check-release-pending.sh`
-  reports deployable commits the trunk has accumulated since the last
-  annotated tag, and shipped code whose declared version did not move. It
-  cannot see issue state, labels or `CHANGELOG.md`, so (2) and (3) stay a
-  manual check. The `Release pending` workflow runs the script on every push
-  to `main` and is advisory — it never blocks a merge.
+  `check-release-pending.sh` only reads the constant) — shipping changed code
+  under a version string already live in production means
+  `Plugin::maybe_upgrade()` never fires. Flag any of these that is missing
+  instead of assuming the owner will remember. Only (4) is automated:
+  `tools/check-release-pending.sh` reports deployable commits the trunk has
+  accumulated since the last annotated tag, and shipped code whose declared
+  version did not move. It cannot see issue state, labels or `CHANGELOG.md`,
+  so (2) and (3) stay a manual check. The `Release pending` workflow runs the
+  script on every push to `main` and is advisory — it never blocks a merge.
+- **Labels are part of opening a PR, not an afterthought** (ADR 0019 §7).
+  Three axes coexist and a PR may carry several: exactly one `type: *`
+  (`feat`/`fix`/`docs`/`chore`/`refactor`/`ci`/`test`/`perf`/`revert`),
+  derived from the Conventional Commits prefix of the title by the `Labels`
+  workflow; `next`/`planned`/`deferred` on **issues only**, mirroring
+  `docs/adr/BACKLOG.md` and stripped automatically when the issue closes;
+  and GitHub's defaults (`documentation`, `bug`, `enhancement`,
+  `help wanted`, `dependencies`, …) as an optional complementary axis, added
+  by hand when they say something the type does not. Never put a backlog
+  state on a PR. If the workflow warns that no type could be derived, fix
+  the **title** — it is the title that violates Conventional Commits, and
+  the label is only the symptom.
 - **Production deploy is its own release, never a follow-up to a merge**
   (ADR 0020). It needs an annotated `vX.Y.Z` on a commit that already went
   through the `VERSION.md` procedure; `deploy-wordpress.yml` refuses an

--- a/README.md
+++ b/README.md
@@ -189,6 +189,32 @@ Runbook: `docs/operations/wordpress-manual-deployment.md`.
 Siguiente: no pisar la carga en curso; QA de producción; FSE después, primero
 en Docker (ADR 0015).
 
+## Flujo de trabajo (ADR 0019)
+
+No se commitea directo a `main`: rama corta, PR, CI verde, merge (squash
+preferido). Ramas según [Conventional Branch 1.1.0](https://conventionalbranch.org/),
+commits según [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/),
+comentarios de review según [Conventional Comments](https://conventionalcomments.org/).
+
+**Etiquetas.** Un PR o issue admite varias; hay tres ejes que conviven:
+
+| Eje | Dónde | Cuántas | Quién la pone |
+|---|---|---|---|
+| `type: *` (`feat`, `fix`, `docs`, `chore`, `refactor`, `ci`, `test`, `perf`, `revert`) | PRs e issues | **exactamente una** | el workflow `Labels`, derivándola del prefijo del título |
+| `next` / `planned` / `deferred` | **solo** issues | máximo una | a mano, según `docs/adr/BACKLOG.md` |
+| `documentation`, `bug`, `enhancement`, `help wanted`, `dependencies`… | PRs e issues | las que aporten | a mano (Dependabot pone las suyas) |
+
+Dos reglas que se olvidan y por eso están automatizadas:
+
+- **La etiqueta de tipo sale del título.** Si el título no empieza por un
+  prefijo válido (`docs:`, `fix(tools):`, `feat!:` …), el workflow avisa y
+  no etiqueta. Se arregla corrigiendo el título, no la etiqueta.
+- **`next`/`planned`/`deferred` es estado, no historia.** Al cerrar el
+  issue se retiran solas. Retirarlas no cierra el ítem: sigue habiendo que
+  moverlo en `docs/adr/BACKLOG.md` y anotar `CHANGELOG.md`.
+
+Detalle y motivos: `docs/adr/0019-proteger-main-trunk-based.md` §7.
+
 ## Licencia
 
 - **Código** (HTML, CSS, JS, PHP, scripts y configuración): **MIT**. Ver `LICENSE`.

--- a/docs/adr/0019-proteger-main-trunk-based.md
+++ b/docs/adr/0019-proteger-main-trunk-based.md
@@ -165,6 +165,45 @@ Los comentarios de review (humano o Copilot) siguen
 `<label> [decorations]: <subject>`. Por defecto `(non-blocking)`.
 `(blocking)` es guía para el autor, no un candado de GitHub.
 
+### 7. Etiquetas de issues y PRs
+
+Un PR admite varias etiquetas. Se usan **tres ejes** que conviven; una
+etiqueta pertenece a uno solo.
+
+**Tipo (`type: *`) — obligatoria, exactamente una, en PRs e issues.**
+`type: feat`, `type: fix`, `type: docs`, `type: chore`, `type: refactor`,
+`type: ci`, `type: test`, `type: perf`, `type: revert`. Son los nueve tipos
+de §4: la etiqueta **es** el prefijo del título hecho filtrable, no un
+criterio nuevo que discutir en cada PR. Por eso se deriva sola.
+
+**Estado de backlog (`next` / `planned` / `deferred`) — solo issues, como
+máximo una.** Refleja la sección de `docs/adr/BACKLOG.md` donde vive el
+ítem. Es **estado, no historia**: al cerrar el issue se retira. Un issue
+resuelto que conserva `next` miente sobre lo que queda por hacer. Nunca en
+un PR: un PR no vive en el backlog.
+
+**Complementarias — opcionales, las que hagan falta.** Los defaults de
+GitHub (`documentation`, `bug`, `enhancement`, `help wanted`,
+`good first issue`, `question`, `duplicate`, `invalid`, `wontfix`) y las
+que pone Dependabot (`dependencies`, `github_actions`, `javascript`). Se
+ponen a mano —salvo las de Dependabot— y conviven con `type: *`. La regla
+es que aporten: `dependencies` dice algo que `type: chore` no dice, y
+`help wanted` o `question` no tienen equivalente en ningún otro eje.
+`documentation`, `bug` y `enhancement` son casi sinónimos de `type: docs`,
+`type: fix` y `type: feat`; usarlas está bien, pero como decisión, no como
+duplicado automático.
+
+**Se aplican solas** (`.github/workflows/labels.yml`, sin secretos ni
+acciones de terceros): `type: *` se deriva del título al abrir, reabrir,
+retitular o sacar de draft un PR, retirando las `type: *` que sobren;
+`next`/`planned`/`deferred` se retiran al cerrar un issue. El workflow no
+añade ni quita ninguna etiqueta del tercer eje. Es aplicación, no candado:
+no bloquea el merge, igual que `Release pending` (ADR 0020). Si el título
+no lleva un prefijo válido, avisa y no inventa etiqueta.
+
+Retirar el estado de backlog **no** cierra el ítem: sigue haciendo falta
+moverlo en `docs/adr/BACKLOG.md`, cerrar el issue y anotar `CHANGELOG.md`.
+
 ## Alternativas consideradas
 
 | Alternativa | Motivo de descarte |
@@ -176,6 +215,10 @@ Los comentarios de review (humano o Copilot) siguen
 | 1 approval obligatorio | Uno puede bloquear al otro; si queda una sola persona, el repo se para. |
 | Bypass de administrador | `main` seguiría abierta para `refo44`; el colaborador no tiene el mismo camino. |
 | Restringir nombres de rama en el ruleset | Rompe `dependabot/*`; el spec se aplica por convención. |
+| Usar `documentation`/`enhancement`/`bug` **como** eje de tipo | Los nombres no casan con los prefijos de §4: obligaría a traducir `docs:` → `documentation` y `feat:` → `enhancement` en cada PR, y no cubre `ci`, `test`, `chore`, `refactor`, `perf` ni `revert`. Como eje complementario sí se admiten. |
+| Etiquetar a mano, solo documentado | Es justo el paso que ya se demostró olvidable: 18 de los 22 PRs sin etiqueta de tipo y dos con estado de backlog que no les correspondía. |
+| Check que bloquee el merge si falta etiqueta | El candado es Tests (§2). Una etiqueta derivable del título no justifica un segundo candado, y bloquearía PRs correctos por un título aún sin pulir. |
+| Acción de terceros (`actions/labeler`, `pr-labeler`) | Dependencia y superficie extra para un `sed` y dos llamadas a `gh` que ya vienen en el runner. |
 | `commit-check-action` / commitlint ahora | Dependencia de CI extra; no cubre Dependabot ni merge commits; YAGNI. |
 | Forzar patrón de mensaje en el ruleset | Rompe *Merge pull request #N*; el spec se aplica al commitear y al squash. |
 | Ruleset de inserción (push) | Plan Team / repos privados; no es el problema. |
@@ -211,12 +254,29 @@ Nota factual; no sustituye las decisiones de este ADR.
   etiquetas `vX.Y.Z`. Las cinco ramas remotas ya mergeadas que habían
   quedado se eliminaron el mismo día.
 
+## Estado de implementación (2026-08-29)
+
+Nota factual; no sustituye las decisiones de este ADR.
+
+- Creadas las nueve etiquetas `type: *`.
+- Backfill de los 22 PRs existentes: 18 derivadas del prefijo del título;
+  cuatro a mano (#6, #7, #8, #14) por ser anteriores a este ADR y no llevar
+  prefijo Conventional Commits.
+- Retiradas `next` de [PR #17](https://github.com/refo44/demo-revistalogos/pull/17)
+  y `planned` de [PR #16](https://github.com/refo44/demo-revistalogos/pull/16):
+  eran estado de backlog en PRs. Retirada `next` del
+  [issue #9](https://github.com/refo44/demo-revistalogos/issues/9), cerrado
+  desde el 2026-08-28.
+- Workflow `Labels` (`.github/workflows/labels.yml`), dos jobs, sin
+  secretos y sin checkout del código del PR.
+
 ## Referencias
 
 - [Trunk-Based Development](https://trunkbaseddevelopment.com/)
 - [Conventional Branch 1.1.0](https://conventionalbranch.org/)
 - [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
 - [Conventional Comments](https://conventionalcomments.org/)
+- [Administrar etiquetas](https://docs.github.com/es/issues/using-labels-and-milestones-to-track-work/managing-labels)
 - [Acerca de los conjuntos de reglas](https://docs.github.com/es/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
 - [Creación de conjuntos de reglas de un repositorio](https://docs.github.com/es/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
 - [Reglas disponibles](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -168,7 +168,7 @@ Ruleset `Protect main (trunk-based)` (`21337399`), activo, sin bypass. `main` ex
 
 No hay dependencia ADR que fuerce el orden entre diseño editorial y WU7. Se planificó **diseño antes de WU7** para que Generate/Regenerate consuman la misma plantilla (evitar dos sistemas de presentación); el ítem 3 ya está **completado y en `main`**, así que WU7 (ítem 4) es lo siguiente y debe consumir esa plantilla. El spike de la sección «Cómo Citar» (ítem 9) es **independiente** de 3 y 4: presentación del theme clásico, no PDF.
 
-Un ítem que termina se cierra en los tres sitios a la vez: este estado, el issue de GitHub (cerrar y quitar la etiqueta `next`/`planned`/`deferred`) y `CHANGELOG.md`. Si además tocó theme o plugin, entra en el siguiente release etiquetado (ADR 0020); `tools/check-release-pending.sh` avisa cuando ese último paso queda pendiente.
+Un ítem que termina se cierra en los tres sitios a la vez: este estado, el issue de GitHub y `CHANGELOG.md`. La etiqueta `next`/`planned`/`deferred` la retira sola el workflow `Labels` al cerrar el issue (ADR 0019 §7); mover la entrada **aquí** no lo hace nadie. Si además tocó theme o plugin, entra en el siguiente release etiquetado (ADR 0020); `tools/check-release-pending.sh` avisa cuando ese último paso queda pendiente.
 
 #### 3. Diseño editorial profesional del PDF de artículo
 


### PR DESCRIPTION
## Por qué

De los 22 PRs del repositorio, **18 no llevaban ninguna etiqueta**. Y dos de los cuatro que sí la llevaban, la llevaban mal:

| | tenía | problema |
|---|---|---|
| [#16](https://github.com/refo44/demo-revistalogos/pull/16) | `planned` | estado de backlog de *issues*, puesto en un PR |
| [#17](https://github.com/refo44/demo-revistalogos/pull/17) | `next` | igual |
| [issue #9](https://github.com/refo44/demo-revistalogos/issues/9) | `next` | **cerrado desde el 2026-08-28** y aún marcado como lo siguiente a hacer |

Lo del issue #9 es lo que más pesa: `CLAUDE.md` ya exigía retirar esa etiqueta al cerrar («the GitHub issue closed **and** its `next`/`planned`/`deferred` label removed»), y aun así sobrevivió tres días a la vista de todos.

No fue descuido. **No existía taxonomía de tipo para PRs**, así que no había nada que recordar aplicar: las únicas etiquetas consistentes del repo eran las que Dependabot se pone a sí mismo.

## Decisión — tres ejes que conviven (ADR 0019 §7)

Un PR admite varias etiquetas, así que no hay que elegir una convención u otra:

| Eje | Dónde | Cuántas | Quién |
|---|---|---|---|
| **`type: *`** — `feat` `fix` `docs` `chore` `refactor` `ci` `test` `perf` `revert` | PRs e issues | **exactamente una** | el workflow, derivándola del título |
| **`next` / `planned` / `deferred`** | **solo** issues | máximo una | a mano, según `BACKLOG.md` |
| **Defaults de GitHub y Dependabot** — `documentation`, `bug`, `enhancement`, `help wanted`, `dependencies`… | PRs e issues | las que aporten | a mano |

La clave del primer eje: **son los nueve tipos de Conventional Commits que ADR 0019 §4 ya exige en el título.** La etiqueta no es un criterio nuevo que discutir en cada PR — es el prefijo que el título ya lleva, hecho filtrable. Por eso se puede derivar sola y no hace falta que nadie juzgue nada.

Sobre el tercer eje: la regla es que **aporte**. `dependencies` dice algo que `type: chore` no dice, y `help wanted` o `question` no tienen equivalente en ningún otro eje. `documentation`, `bug` y `enhancement` son casi sinónimos de su `type: *`; usarlas está bien, pero como decisión deliberada, no como duplicado automático.

## Automatización

`.github/workflows/labels.yml` — dos jobs, **sin secretos, sin acciones de terceros y sin checkout del código del PR** (`gh` ya viene en el runner):

- **PR** abierto, reabierto, retitulado o sacado de draft → deriva `type: *` del prefijo del título y retira las `type: *` que sobren. Si el título no lleva prefijo válido, **avisa y no inventa etiqueta**: el fallo está en el título, y se arregla ahí.
- **Issue cerrado** → retira `next`/`planned`/`deferred`, y recuerda que mover la entrada en `BACKLOG.md` no lo automatiza nadie.

No toca el tercer eje —nunca añade ni quita un default— y **no bloquea el merge**. El candado sigue siendo Tests (ADR 0019 §2). Una etiqueta derivable del título no justifica un segundo candado, y bloquear PRs por un título aún sin pulir sería peor que el problema.

Es el mismo patrón que `check-release-pending.sh`: atacar la causa en vez de confiar en que alguien se acuerde.

## Estado ya corregido en el repo

- **22/22 PRs con `type: *`.** 18 derivadas del prefijo del título; cuatro a mano (#6, #7, #8, #14) por ser anteriores a ADR 0019 y no llevar prefijo Conventional Commits.
- Retiradas `planned` de #16, `next` de #17 y `next` del issue #9.
- **Ningún issue cerrado conserva estado de backlog.** Los cuatro abiertos (#11, #12, #13, #15) ya estaban correctos.
- Añadidas complementarias donde aportan: `documentation` en los PRs de documentación que no la tenían, `enhancement` en #20, `bug` en #14 y #21.

## Documentación

- **ADR 0019 §7** (nueva), más cuatro filas en *Alternativas consideradas* y una nota de implementación fechada. Es el ADR de convenciones de proceso —ramas §3, commits §4, comentarios §6—, así que las etiquetas son la misma familia; no relitiga nada.
- **`README.md`**: nueva sección «Flujo de trabajo», que además era el único sitio donde el README no decía absolutamente nada sobre ramas, PRs ni commits.
- **`CLAUDE.md`**: regla propia, y el checklist de cierre corregido — ahora distingue lo que el workflow hace solo (retirar la etiqueta) de lo que sigue siendo manual (mover la entrada en `BACKLOG.md`).
- **`docs/adr/BACKLOG.md`** y **`CHANGELOG.md`**.

## Verificación

Lógica del labeler probada con un stub de `gh`, seis casos:

| Caso | Resultado |
|---|---|
| PR nuevo sin etiquetas | aplica `type: feat` |
| Retitulado `docs:` → `fix:` | quita `type: docs`, pone `type: fix` |
| Etiqueta ya correcta | no toca nada |
| Dos `type: *` a la vez | deja una |
| `feat!:` (breaking change) | aplica `type: feat` |
| Título sin prefijo válido | avisa y sale 0 |

La derivación se contrastó además contra **los 22 títulos reales** del repo: 18 aciertos y los cuatro pre-ADR correctamente detectados como «sin prefijo». YAML validado con `js-yaml`.

## Nota

**El workflow no se ejecutará en este PR.** `pull_request_target` corre la definición que vive en la rama base, y ahí todavía no existe: la etiqueta `type: ci` de este PR está puesta a mano. Empieza a aplicarse solo con el primer PR posterior al merge.

Toca `README.md` y `CLAUDE.md`, igual que #28. Son secciones distintas, pero el segundo en mergearse probablemente pedirá un rebase trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
