### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.1] — 2026-08-31
+
+Release etiquetado para FTPS de producción (ADR 0020). Incluye el fix
+urgente de Gutenberg [#30](https://github.com/refo44/demo-revistalogos/issues/30)
+/[#31](https://github.com/refo44/demo-revistalogos/pull/31) (plugin
+`revistalogos-core` **0.2.10**) y el resto de `main` acumulado desde
+`v0.3.0`. Theme sin cambio (**0.2.1**).
+
 ### Fixed
 - Plugin `revistalogos-core` 0.2.10: publicar un artículo en borrador
   desde Gutenberg ya no falla cuando el autor publicado está asignado
@@ -42,7 +50,6 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
   retitular o sacar de draft un PR y retira el estado de backlog al cerrar
   un issue; sin secretos, sin acciones de terceros y sin checkout del código
   del PR. Advisory: no bloquea el merge.
-
 
 ### Changed
 - Los pies de `docs/` dejan de repetir la versión del proyecto. Siete

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.0**
+**Versión vigente: 0.3.1**
 
 ## Fuente de verdad
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",


### PR DESCRIPTION
## Summary
- Project release **0.3.1** for production FTPS (ADR 0020 / `VERSION.md`).
- Moves `[Sin publicar]` → `[0.3.1] — 2026-08-31` in `CHANGELOG.md`; bumps `package.json` / lock / `VERSION.md`.
- Ships plugin **`revistalogos-core` 0.2.10** already on `main` via #31 (Gutenberg classic-metabox meta sync, #30). Theme stays **0.2.1**.

## After merge
```bash
git fetch --tags origin main
git tag -a v0.3.1 -m "v0.3.1" origin/main
git push origin v0.3.1
```
Then Actions → Deploy WordPress theme+plugin to production → Run workflow **from tag `v0.3.1`** (not from `main`).

## Test plan
- [ ] CI green on this PR
- [ ] After merge: `git show v0.3.1:package.json | grep '"version"'` → `0.3.1`
- [ ] `git show v0.3.1:.../revistalogos-core.php | grep REVISTALOGOS_CORE_VERSION` → `0.2.10`
- [ ] `./tools/require-production-release-tag.sh` passes on the tagged commit


Made with [Cursor](https://cursor.com)