### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.2] — 2026-09-05
+
+Release etiquetado para FTPS de producción (ADR 0020). Incluye el
+hero de portada ([#40](https://github.com/refo44/demo-revistalogos/issues/40)
+/[#41](https://github.com/refo44/demo-revistalogos/pull/41), theme
+`revistalogos` **0.2.2**) y el resto de `main` acumulado desde
+`v0.3.1`. Plugin sin cambio (**0.2.10**).
+
 ### Changed
 - Home hero: banner letter-free (same landscape, cropped to 1714×356)
   and the description drops the redundant `LOGO ET SPES` already in the

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.1**
+**Versión vigente: 0.3.2**
 
 ## Fuente de verdad
 

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -158,9 +158,10 @@ Trabajo **ya aceptado** y **no iniciado** (o no cerrado en producción). No es u
 
 #### 0. Home hero — banner sin letras y párrafo sin nombre repetido
 
-**Estado:** en rama `fix/home-hero-banner-copy` ([issue #40](https://github.com/refo44/demo-revistalogos/issues/40)).
-
-Sustituir `banner-main.jpg` por el mismo paisaje sin «LOGO ET SPES» pintado, recortado a 1714×356. Conservar el `h1` del hero. Quitar solo esas dos palabras del párrafo de descripción (`docs/09` y `front-page.php`).
+**Estado:** ✅ **COMPLETADO Y EN `main`.** Mergeado el 2026-09-05 por
+[PR #41](https://github.com/refo44/demo-revistalogos/pull/41);
+[issue #40](https://github.com/refo44/demo-revistalogos/issues/40) cerrado.
+Se publica en **theme 0.2.2 / proyecto v0.3.2**. Plugin sin cambio.
 
 #### 1. Checkpoint de producción — plugin 0.2.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",


### PR DESCRIPTION
## Summary
- Project version **0.3.2** (`package.json`, `package-lock.json`, `VERSION.md`).
- Moves `[Sin publicar]` into `[0.3.2] — 2026-09-05`: theme **0.2.2** home hero ([#40](https://github.com/refo44/demo-revistalogos/issues/40) / [#41](https://github.com/refo44/demo-revistalogos/pull/41)); plugin stays **0.2.10**.
- Marks BACKLOG item 0 (home hero) completed. `docs/` feet are not versioned (`VERSION.md`).

## Test plan
- [ ] `package.json` version is `0.3.2` and matches `VERSION.md` / `CHANGELOG.md` heading
- [ ] Theme header remains `0.2.2`; plugin headers remain `0.2.10`
- [ ] CI Tests check green
- [ ] After merge: annotated tag `v0.3.2` on `origin/main` (do not dispatch FTPS from this PR)


Made with [Cursor](https://cursor.com)