### PR TITLE
feat(plugin): serve native sitemap without users or search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+### Added
+- Plugin `revistalogos-core` 0.2.11: sitemap nativo sin provider `users`,
+  `/buscar/` fuera del sitemap de páginas y con `noindex,follow` vía
+  `wp_robots`, y HTTP 200 temporal solo en WordPress 7.1 (Trac #65945;
+  se apaga en 7.1.1+). Un 404 ordinario no se convierte en 200.
+  Sin SiteSEO.
+
 ## [0.3.2] — 2026-09-05
 
 Release etiquetado para FTPS de producción (ADR 0020). Incluye el

--- a/tests/Features/native-sitemap-discoverability.feature
+++ b/tests/Features/native-sitemap-discoverability.feature
@@ -1,0 +1,38 @@
+# language: es
+Característica: Sitemap nativo y visibilidad de /buscar/
+  Como revista académica
+  quiero que el sitemap nativo de WordPress liste el contenido público
+  y no las cuentas de wp-admin ni el buscador
+  para que Google y los agentes de IA indexen números, artículos y autores
+  # Ejecutan: tests/WordPress/NativeSitemapDiscoverabilityTest (composer test:wp).
+  # Workaround HTTP 200 en sitemaps: retirar cuando WordPress mínimo sea 7.1.1+
+  # (Trac #65945).
+
+  Escenario: El índice nativo no anuncia cuentas de WordPress
+    Dado el sitemap nativo de WordPress
+    Cuando se genera el índice
+    Entonces no incluye el provider users
+    Y sí incluye article, issue y author
+
+  Escenario: La búsqueda no es una landing indexable
+    Dado la página /buscar/ publicada
+    Cuando se genera el sitemap de páginas
+    Entonces /buscar/ no aparece
+    Y la página envía noindex
+
+  Escenario: Sin entradas nativas el sitemap no es 404
+    Dado que no hay posts nativos publicados
+    Y WordPress es 7.1
+    Cuando se solicita /wp-sitemap.xml
+    Entonces pre_handle_404 adelanta el 404
+    Y la respuesta no es 404
+
+  Escenario: Un 404 ordinario no lo convierte el workaround
+    Dado una URL pública que no existe
+    Cuando se resuelve la petición
+    Entonces sigue siendo 404
+
+  Escenario: WordPress 7.1.1 o posterior no usa el parche
+    Dado WordPress 7.0, 7.1.1 o 7.2
+    Cuando se evalúa el gate del workaround
+    Entonces no se aplica

--- a/tests/Support/bootstrap.php
+++ b/tests/Support/bootstrap.php
@@ -29,3 +29,4 @@ require_once $article_pdf_dir . '/class-article-pdf-editorial-template.php';
 require_once $article_pdf_dir . '/interface-article-pdf-renderer.php';
 require_once $article_pdf_dir . '/class-article-pdf-generation-orchestrator.php';
 require_once $article_pdf_dir . '/class-dompdf-article-pdf-renderer.php';
+require_once $plugin_root . '/includes/integrations/class-native-sitemap.php';

--- a/tests/Unit/Wp71SitemapWorkaroundTest.php
+++ b/tests/Unit/Wp71SitemapWorkaroundTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Version gate for the WordPress 7.1 native sitemap 404 workaround
+ * (Trac #65945). Pure: no WordPress boot.
+ *
+ * @package Revistalogos
+ */
+
+use PHPUnit\Framework\TestCase;
+
+use function Revistalogos_Core\needs_wp71_sitemap_workaround;
+
+/**
+ * The workaround is only for the 7.1 series, before the 7.1.1 Core fix.
+ */
+class Wp71SitemapWorkaroundTest extends TestCase {
+
+	/**
+	 * @dataProvider versions_that_need_the_workaround
+	 *
+	 * @param string $version WordPress version string.
+	 */
+	public function test_workaround_applies_only_to_the_7_1_series_before_7_1_1( $version ) {
+		$this->assertTrue( needs_wp71_sitemap_workaround( $version ) );
+	}
+
+	/**
+	 * @dataProvider versions_that_must_not_use_the_workaround
+	 *
+	 * @param string $version WordPress version string.
+	 */
+	public function test_workaround_does_not_apply_outside_7_1_before_patch( $version ) {
+		$this->assertFalse( needs_wp71_sitemap_workaround( $version ) );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function versions_that_need_the_workaround() {
+		return array(
+			'7.1'   => array( '7.1' ),
+			'7.1.0' => array( '7.1.0' ),
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function versions_that_must_not_use_the_workaround() {
+		return array(
+			'6.4'   => array( '6.4' ),
+			'7.0.4' => array( '7.0.4' ),
+			'7.1.1' => array( '7.1.1' ),
+			'7.2'   => array( '7.2' ),
+		);
+	}
+}

--- a/tests/WordPress/NativeSitemapDiscoverabilityTest.php
+++ b/tests/WordPress/NativeSitemapDiscoverabilityTest.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Native WordPress sitemap contract for public discoverability:
+ * journal CPTs stay listed, wp-admin users do not, /buscar/ is not a
+ * landing, and sitemap requests are not 404 when no native posts exist
+ * (WordPress 7.1 / Trac #65945).
+ *
+ * @package Revistalogos
+ */
+
+use Revistalogos_Core\Content_Types;
+use Revistalogos_Core\Native_Sitemap;
+use Revistalogos_Core\Taxonomies;
+
+/**
+ * Protects what Google and AI crawlers receive from /wp-sitemap.xml
+ * after SiteSEO is out of the way.
+ */
+class NativeSitemapDiscoverabilityTest extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		Content_Types::register();
+		Taxonomies::register();
+		Taxonomies::insert_initial_terms();
+		if ( function_exists( 'wp_sitemaps_get_server' ) ) {
+			wp_sitemaps_get_server()->register_rewrites();
+		}
+		$this->set_permalink_structure( '/%postname%/' );
+	}
+
+	/**
+	 * Dado: no hay entradas nativas `post` publicadas.
+	 * Cuando: se solicita el índice nativo de sitemaps.
+	 * Entonces: la petición no es 404 (workaround WP 7.1 / Trac #65945;
+	 * retirar cuando el mínimo de WordPress sea 7.1.1 o superior).
+	 */
+	public function test_sitemap_index_is_not_404_when_no_published_posts() {
+		$this->unpublish_native_posts();
+		$this->make_published_page( 'acerca', 'Acerca' );
+
+		$this->go_to( home_url( '/?sitemap=index' ) );
+
+		$this->assertNotEmpty( get_query_var( 'sitemap' ), 'the request must be recognized as a sitemap' );
+		$this->assertFalse( is_404(), 'WordPress 7.1 must not mark a populated sitemap as 404 when no posts exist' );
+		$this->assertTrue(
+			Native_Sitemap::keep_sitemap_from_404( false, $GLOBALS['wp_query'] ),
+			'pre_handle_404 must short-circuit only for a recognized sitemap request'
+		);
+	}
+
+	/**
+	 * Dado: una URL pública que no existe.
+	 * Entonces: el workaround no convierte el 404 en 200.
+	 */
+	public function test_ordinary_missing_url_stays_404() {
+		$this->go_to( home_url( '/esta-ruta-no-existe-les/' ) );
+
+		$this->assertEmpty( get_query_var( 'sitemap' ) );
+		$this->assertTrue( is_404() );
+		$this->assertFalse(
+			Native_Sitemap::keep_sitemap_from_404( false, $GLOBALS['wp_query'] )
+		);
+	}
+
+	/**
+	 * Dado: el sitemap nativo de WordPress.
+	 * Entonces: no anuncia el provider de cuentas wp-admin (`users`).
+	 */
+	public function test_sitemap_index_omits_the_users_provider() {
+		$registry = wp_sitemaps_get_server()->registry;
+		$this->assertNull( $registry->get_provider( 'users' ) );
+
+		$locs = $this->sitemap_index_locs();
+
+		foreach ( $locs as $loc ) {
+			$this->assertStringNotContainsString(
+				'wp-sitemap-users',
+				$loc,
+				'CPT author is the public author surface; wp-admin users must not be in the sitemap'
+			);
+		}
+	}
+
+	/**
+	 * Dado: el registro nativo de sitemaps.
+	 * Entonces: posts y taxonomies siguen registrados.
+	 */
+	public function test_posts_and_taxonomies_providers_remain_registered() {
+		$registry = wp_sitemaps_get_server()->registry;
+
+		$this->assertInstanceOf( \WP_Sitemaps_Provider::class, $registry->get_provider( 'posts' ) );
+		$this->assertInstanceOf( \WP_Sitemaps_Provider::class, $registry->get_provider( 'taxonomies' ) );
+	}
+
+	/**
+	 * Dado: una página /buscar/ publicada.
+	 * Entonces: no aparece en el sitemap de páginas.
+	 */
+	public function test_pages_sitemap_omits_the_search_page() {
+		$acerca_id = $this->make_published_page( 'acerca', 'Acerca' );
+		$buscar_id = $this->make_published_page( 'buscar', 'Buscar' );
+
+		$provider = wp_sitemaps_get_server()->registry->get_provider( 'posts' );
+		$url_list = $provider->get_url_list( 1, 'page' );
+		$locs     = wp_list_pluck( $url_list, 'loc' );
+
+		$this->assertContains( get_permalink( $acerca_id ), $locs );
+		$this->assertNotContains( get_permalink( $buscar_id ), $locs );
+
+		$filtered = Native_Sitemap::exclude_search_page( array(), 'page' );
+		$this->assertContains( $buscar_id, $filtered['post__not_in'] );
+	}
+
+	/**
+	 * Dado: query args de article, issue o author.
+	 * Entonces: el filtro de páginas no los altera.
+	 */
+	public function test_non_page_sitemap_query_args_are_unchanged() {
+		$args = array(
+			'orderby' => 'ID',
+			'order'   => 'ASC',
+		);
+
+		foreach ( array( 'article', 'issue', 'author' ) as $post_type ) {
+			$this->assertSame( $args, Native_Sitemap::exclude_search_page( $args, $post_type ) );
+		}
+	}
+
+	/**
+	 * Dado: la página /buscar/.
+	 * Cuando: se renderizan las directivas robots.
+	 * Entonces: incluye noindex.
+	 */
+	public function test_search_page_sends_noindex() {
+		$buscar_id = $this->make_published_page( 'buscar', 'Buscar' );
+
+		$this->go_to( get_permalink( $buscar_id ) );
+
+		$robots = apply_filters( 'wp_robots', array( 'index' => true ) );
+
+		$this->assertTrue( is_page( 'buscar' ) );
+		$this->assertArrayNotHasKey( 'index', $robots );
+		$this->assertTrue( (bool) $robots['noindex'] );
+		$this->assertTrue( (bool) $robots['follow'] );
+	}
+
+	/**
+	 * Dado: una página institucional.
+	 * Entonces: no recibe noindex por el filtro de /buscar/.
+	 */
+	public function test_institutional_page_is_not_forced_noindex() {
+		$acerca_id = $this->make_published_page( 'acerca', 'Acerca' );
+
+		$this->go_to( get_permalink( $acerca_id ) );
+
+		$robots = apply_filters( 'wp_robots', array() );
+
+		$this->assertTrue( is_page( 'acerca' ) );
+		$this->assertArrayNotHasKey( 'noindex', $robots );
+	}
+
+	/**
+	 * Dado: los CPT y la taxonomía públicos del journal.
+	 * Entonces: el sitemap nativo sigue ofreciendo article, issue, author
+	 * y article_type (no se excluyen).
+	 */
+	public function test_journal_public_types_remain_in_native_sitemap() {
+		$posts = wp_sitemaps_get_server()->registry->get_provider( 'posts' );
+		$this->assertInstanceOf( \WP_Sitemaps_Provider::class, $posts );
+		$post_types = $posts->get_object_subtypes();
+		$this->assertArrayHasKey( 'article', $post_types );
+		$this->assertArrayHasKey( 'issue', $post_types );
+		$this->assertArrayHasKey( 'author', $post_types );
+
+		$taxonomies = wp_sitemaps_get_server()->registry->get_provider( 'taxonomies' );
+		$this->assertInstanceOf( \WP_Sitemaps_Provider::class, $taxonomies );
+		$this->assertArrayHasKey( Taxonomies::ARTICLE_TYPE, $taxonomies->get_object_subtypes() );
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function sitemap_index_locs() {
+		$list = wp_sitemaps_get_server()->index->get_sitemap_list();
+
+		return wp_list_pluck( $list, 'loc' );
+	}
+
+	/**
+	 * @param string $slug  Page slug.
+	 * @param string $title Page title.
+	 * @return int
+	 */
+	private function make_published_page( $slug, $title ) {
+		return (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_name'   => $slug,
+				'post_title'  => $title,
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Reproduce the production condition: no published native posts.
+	 */
+	private function unpublish_native_posts() {
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+			)
+		);
+
+		foreach ( $posts as $post ) {
+			wp_update_post(
+				array(
+					'ID'          => $post->ID,
+					'post_status' => 'private',
+				)
+			);
+		}
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
@@ -49,6 +49,7 @@ class Plugin {
 		Contact_Form_Integration::register_hooks();
 		Article_Pdf_Publication_Settings::register_hooks();
 		Article_Pdf_Publication_Enforcer::register_hooks();
+		Native_Sitemap::register_hooks();
 
 		// Idempotent upgrade: late on init so CPT rewrite args are
 		// registered before a version-gated rewrite flush.
@@ -84,6 +85,7 @@ class Plugin {
 		require_once $includes . 'queries/class-queries.php';
 		require_once $includes . 'integrations/class-comments-disabler.php';
 		require_once $includes . 'integrations/class-contact-form-integration.php';
+		require_once $includes . 'integrations/class-native-sitemap.php';
 		require_once $includes . 'migration/class-content-migrator.php';
 		require_once $includes . 'fixtures/class-fixtures.php';
 		require_once $includes . 'article-pdf/class-article-pdf-publication-policy.php';

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-native-sitemap.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-native-sitemap.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Native WordPress sitemap and robots for public discoverability.
+ * No SiteSEO. CPT author is the public author surface.
+ *
+ * @package Revistalogos_Core
+ */
+
+namespace Revistalogos_Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Whether the WordPress 7.1 sitemap HTTP 404 workaround should run.
+ *
+ * Remove when the plugin's minimum WordPress version is 7.1.1 or later.
+ *
+ * @see https://core.trac.wordpress.org/ticket/65945
+ *
+ * @param string $wp_version WordPress version string.
+ * @return bool
+ */
+function needs_wp71_sitemap_workaround( $wp_version ) {
+	return version_compare( $wp_version, '7.1', '>=' )
+		&& version_compare( $wp_version, '7.1.1', '<' );
+}
+
+/**
+ * Drops wp-admin users from the sitemap, keeps /buscar/ out of the
+ * page sitemap and noindex, and works around WordPress 7.1 serving
+ * populated sitemaps as HTTP 404 when no native posts are published.
+ */
+class Native_Sitemap {
+
+	const SEARCH_PAGE_SLUG = 'buscar';
+
+	/**
+	 * Wire filters. Called from Plugin::boot() before init so
+	 * wp_sitemaps_add_provider runs when Core registers providers.
+	 */
+	public static function register_hooks() {
+		add_filter( 'wp_sitemaps_add_provider', array( __CLASS__, 'omit_users_provider' ), 10, 2 );
+		add_filter( 'wp_sitemaps_posts_query_args', array( __CLASS__, 'exclude_search_page' ), 10, 2 );
+		add_filter( 'wp_robots', array( __CLASS__, 'noindex_search_page' ) );
+
+		if ( needs_wp71_sitemap_workaround( self::wordpress_version() ) ) {
+			add_filter( 'pre_handle_404', array( __CLASS__, 'keep_sitemap_from_404' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * @param WP_Sitemaps_Provider|false $provider Provider instance.
+	 * @param string                     $name     Provider name.
+	 * @return WP_Sitemaps_Provider|false
+	 */
+	public static function omit_users_provider( $provider, $name ) {
+		if ( 'users' === $name ) {
+			return false;
+		}
+
+		return $provider;
+	}
+
+	/**
+	 * @param array<string, mixed> $args      WP_Query args.
+	 * @param string               $post_type Post type being listed.
+	 * @return array<string, mixed>
+	 */
+	public static function exclude_search_page( $args, $post_type ) {
+		if ( 'page' !== $post_type ) {
+			return $args;
+		}
+
+		$search_page = get_page_by_path( self::SEARCH_PAGE_SLUG, OBJECT, 'page' );
+		if ( ! $search_page instanceof \WP_Post ) {
+			return $args;
+		}
+
+		$excluded = isset( $args['post__not_in'] ) ? (array) $args['post__not_in'] : array();
+		$excluded[] = (int) $search_page->ID;
+		$args['post__not_in'] = array_values( array_unique( array_map( 'absint', $excluded ) ) );
+
+		return $args;
+	}
+
+	/**
+	 * Single wp_robots meta. The theme does not emit a separate robots tag.
+	 *
+	 * @param array<string, mixed> $robots Robots directives.
+	 * @return array<string, mixed>
+	 */
+	public static function noindex_search_page( $robots ) {
+		if ( ! is_page( self::SEARCH_PAGE_SLUG ) ) {
+			return $robots;
+		}
+
+		unset( $robots['index'], $robots['nofollow'] );
+		$robots['noindex'] = true;
+		$robots['follow']  = true;
+
+		return $robots;
+	}
+
+	/**
+	 * Work around WordPress 7.1 native sitemap HTTP 404 bug.
+	 *
+	 * Only recognized sitemap requests. A sitemap that Core later
+	 * finds empty can still 404 from WP_Sitemaps::render_sitemaps().
+	 * Remove when the minimum supported WordPress version is >= 7.1.1.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/65945
+	 *
+	 * @param bool     $preempt  Whether to short-circuit 404 handling.
+	 * @param WP_Query $wp_query The main query.
+	 * @return bool
+	 */
+	public static function keep_sitemap_from_404( $preempt, $wp_query ) {
+		if ( ! needs_wp71_sitemap_workaround( self::wordpress_version() ) ) {
+			return $preempt;
+		}
+
+		if ( ! get_query_var( 'sitemap' ) && ! get_query_var( 'sitemap-stylesheet' ) ) {
+			return $preempt;
+		}
+
+		if ( $wp_query instanceof \WP_Query ) {
+			$wp_query->is_404 = false;
+		}
+		status_header( 200 );
+
+		return true;
+	}
+
+	/**
+	 * @return string
+	 */
+	private static function wordpress_version() {
+		return isset( $GLOBALS['wp_version'] ) ? (string) $GLOBALS['wp_version'] : get_bloginfo( 'version' );
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -3,7 +3,7 @@ Contributors: cenfiss
 Requires at least: 6.4
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 0.2.10
+Stable tag: 0.2.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,12 @@ Fase 3: los campos `issn`, `doi` y `orcid` son almacenamiento base inerte;
 la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 == Changelog ==
+
+= 0.2.11 =
+* Native sitemap: drop the `users` provider, exclude `/buscar/` from the
+  page sitemap and mark it `noindex,follow`, and force HTTP 200 on
+  sitemap requests only on WordPress 7.1 (Trac #65945; off at 7.1.1+).
+  No SiteSEO.
 
 = 0.2.10 =
 * Gutenberg REST publish of a draft Article now receives and persists

--- a/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Revista LOGO ET SPES — Core
  * Plugin URI:        https://github.com/refo44/demo-revistalogos
  * Description:       Modelo de contenido de la Revista de Filosofía LOGO ET SPES: números, artículos, autores, taxonomías, rol Managing Editor, migración de contenido institucional y fixtures. El theme revistalogos solo presenta; este plugin es el dueño del dominio (ADR 0005).
- * Version:           0.2.10
+ * Version:           0.2.11
  * Requires at least: 6.4
  * Tested up to:      7.1
  * Requires PHP:      7.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_CORE_VERSION', '0.2.10' );
+define( 'REVISTALOGOS_CORE_VERSION', '0.2.11' );
 define( 'REVISTALOGOS_CORE_FILE', __FILE__ );
 define( 'REVISTALOGOS_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'REVISTALOGOS_CORE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- Use the native WordPress sitemap (no SiteSEO): drop the `users` provider so wp-admin accounts are not indexed, and keep journal `article` / `issue` / `author` plus `article_type`.
- Exclude `/buscar/` from the page sitemap (by slug) and mark it `noindex,follow` via `wp_robots` only.
- Temporary HTTP 200 on recognized sitemap requests for WordPress 7.1 only (Trac #65945); the gate turns off at 7.1.1+. Ordinary 404s stay 404.

Plugin **0.2.11**. Theme, `.htaccess`, and deploy pipeline are unchanged.

## Test plan
- [x] `composer test:unit` (includes `Wp71SitemapWorkaroundTest` for 7.0 / 7.1 / 7.1.1 / 7.2)
- [x] `composer test:wp` (20 tests, including sitemap 404 workaround, users omitted, `/buscar/` excluded, institutional page not noindex)
- [ ] After merge and a tagged production deploy: `curl` the native sitemaps for HTTP 200, no `wp-sitemap-users-1.xml`, no `/buscar/` in pages, then submit `https://logo-et-spes.cenfiss.net/wp-sitemap.xml` to Search Console


Made with [Cursor](https://cursor.com)