### PR TITLE
feat(plugin): serve dynamic /llms.txt for AI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 - Plugin `revistalogos-core` 0.2.12: `/llms.txt` generado en cada
   petición (issue #47). Mapa estable de archivos + número actual y
   artículos publicados vía `Queries`. Sin catálogo fijo ni SiteSEO.
-  Un administrador puede actualizarlo a mano desde Ajustes → LOGO ET
-  SPES — llms.txt (vuelve a registrar la URL y muestra el índice vigente).
+  Un administrador puede activarlo, desactivarlo o actualizarlo a mano
+  desde Ajustes → LOGO ET SPES — llms.txt (opción ausente = activado).
   Incluye las páginas institucionales publicadas (acerca, normas, ética,
   políticas, comité, envío, contacto, enlaces, noticias, privacidad).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+### Added
+- Plugin `revistalogos-core` 0.2.12: `/llms.txt` generado en cada
+  petición (issue #47). Mapa estable de archivos + número actual y
+  artículos publicados vía `Queries`. Sin catálogo fijo ni SiteSEO.
+
 ## [0.3.3] — 2026-09-10
 
 Release etiquetado para FTPS de producción (ADR 0020). Incluye el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 - Plugin `revistalogos-core` 0.2.12: `/llms.txt` generado en cada
   petición (issue #47). Mapa estable de archivos + número actual y
   artículos publicados vía `Queries`. Sin catálogo fijo ni SiteSEO.
+  Un administrador puede actualizarlo a mano desde Ajustes → LOGO ET
+  SPES — llms.txt (vuelve a registrar la URL y muestra el índice vigente).
+  Incluye las páginas institucionales publicadas (acerca, normas, ética,
+  políticas, comité, envío, contacto, enlaces, noticias, privacidad).
 
 ## [0.3.3] — 2026-09-10
 

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -293,7 +293,8 @@ Solo trabajo o proceso **ya decidido** y aún no cerrado. Las decisiones **abier
 | Taxonomía `philosopher` | DEFERRED (aplazada en ADR 0005; no es una decisión abierta) | ADR 0005 |
 | HSTS y CSP tras auditoría profesional; GA4 en fase posterior con asesoría legal | DEFERRED | ADR 0012 §3/§6 (D12a, no D12b); ADR 0011 §2 |
 | Activar exigencia PDF en producción | LATER (decisión del propietario; default OFF) | ADR 0017; no es auto-enable |
-| Indexación pública | LATER (launch gate; no la abre el deploy) | ADR 0004; `docs/operations/produccion-wordpress.md` |
+| Indexación pública | Hecha en prod (robots + sitemap nativo, v0.3.3) | ADR 0004; `docs/operations/produccion-wordpress.md` |
+| `/llms.txt` para agentes de IA (AEO) | NEXT ([#47](https://github.com/refo44/demo-revistalogos/issues/47)) | Mapa dinámico en `revistalogos-core`; no `llms-full.txt` |
 | e-ISSN digital / ISSN «en trámite» | LATER (trámite editorial, no software) | ADR 0013; ADR 0004 |
 | Backlog **operativo** de producción (CF7/WP Statistics en el live, Softaculous, restos HTML, permalinks, SpeedyCache, secreto FTP legado, fuente de GitHub Pages) | no duplicar aquí | `docs/operations/produccion-wordpress.md` § Pendientes inmediatos; `docs/fase3-execution-state.md` |
 

--- a/tests/Features/llms-txt-aeo.feature
+++ b/tests/Features/llms-txt-aeo.feature
@@ -18,3 +18,16 @@ Característica: /llms.txt para agentes de IA
     Cuando se genera /llms.txt
     Entonces aparece el número vigente y sus artículos publicados
     Y no aparecen los borradores
+
+  Escenario: Un administrador actualiza /llms.txt desde el plugin
+    Dado un número publicado con artículos publicados
+    Cuando un administrador pulsa Actualizar llms.txt en Ajustes → LOGO ET SPES — llms.txt
+    Entonces el archivo público refleja ese número
+    Y la ruta /llms.txt queda registrada
+
+  Escenario: Las páginas institucionales publicadas entran en el mapa
+    Dado páginas publicadas de normas, ética, políticas y comité
+    Y una página institucional en borrador
+    Cuando se genera /llms.txt
+    Entonces enlaza esas páginas publicadas con su título vigente
+    Y no enlaza el borrador ni la búsqueda

--- a/tests/Features/llms-txt-aeo.feature
+++ b/tests/Features/llms-txt-aeo.feature
@@ -31,3 +31,8 @@ Característica: /llms.txt para agentes de IA
     Cuando se genera /llms.txt
     Entonces enlaza esas páginas publicadas con su título vigente
     Y no enlaza el borrador ni la búsqueda
+
+  Escenario: Un administrador puede desactivar la publicación
+    Dado que llms.txt está desactivado en Ajustes
+    Cuando se solicita la dirección pública
+    Entonces el mapa no se publica

--- a/tests/Features/llms-txt-aeo.feature
+++ b/tests/Features/llms-txt-aeo.feature
@@ -1,0 +1,20 @@
+# language: es
+Característica: /llms.txt para agentes de IA
+  Como revista académica
+  quiero un mapa en texto de la revista que cite el número actual publicado
+  para que los agentes de IA encuentren números y artículos vivos
+  # Issue #47. Ejecutan: tests/Unit/LlmsTxtDocumentTest (composer test:unit)
+  # y tests/WordPress/LlmsTxtCatalogTest (composer test:wp).
+
+  Escenario: El archivo apunta a los archivos vivos y al sitemap
+    Dado el catálogo público de la revista
+    Cuando se genera /llms.txt
+    Entonces nombra Revista de Filosofía LOGO ET SPES
+    Y enlaza números, artículos, autores y el sitemap nativo
+
+  Escenario: El número vigente se lee de objetos publicados
+    Dado un número publicado con artículos publicados
+    Y un número o artículo en borrador
+    Cuando se genera /llms.txt
+    Entonces aparece el número vigente y sus artículos publicados
+    Y no aparecen los borradores

--- a/tests/Support/bootstrap.php
+++ b/tests/Support/bootstrap.php
@@ -30,3 +30,4 @@ require_once $article_pdf_dir . '/interface-article-pdf-renderer.php';
 require_once $article_pdf_dir . '/class-article-pdf-generation-orchestrator.php';
 require_once $article_pdf_dir . '/class-dompdf-article-pdf-renderer.php';
 require_once $plugin_root . '/includes/integrations/class-native-sitemap.php';
+require_once $plugin_root . '/includes/integrations/class-llms-txt.php';

--- a/tests/Unit/LlmsTxtDocumentTest.php
+++ b/tests/Unit/LlmsTxtDocumentTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Markdown shape of /llms.txt (issue #47). No WordPress boot.
+ *
+ * @package Revistalogos
+ */
+
+use PHPUnit\Framework\TestCase;
+use Revistalogos_Core\Llms_Txt;
+
+/**
+ * The file is a stable map plus an optional current-issue block.
+ * It must not invent identifiers or dump the whole catalog.
+ */
+class LlmsTxtDocumentTest extends TestCase {
+
+	/**
+	 * Dado: el catálogo público de la revista.
+	 * Entonces: el documento nombra la revista, los archivos vivos y el sitemap.
+	 */
+	public function test_document_lists_stable_archives_and_sitemap() {
+		$document = Llms_Txt::format_document( $this->empty_catalog() );
+
+		$this->assertStringContainsString( '# Revista de Filosofía LOGO ET SPES', $document );
+		$this->assertStringContainsString( 'https://example.org/revista/numeros/', $document );
+		$this->assertStringContainsString( 'https://example.org/revista/articulos/', $document );
+		$this->assertStringContainsString( 'https://example.org/revista/autores/', $document );
+		$this->assertStringContainsString( 'https://example.org/wp-sitemap.xml', $document );
+		$this->assertStringNotContainsString( 'Número actual', $document );
+	}
+
+	/**
+	 * Dado: un número publicado con artículos.
+	 * Entonces: el documento enlaza ese número y esos artículos.
+	 */
+	public function test_document_lists_current_issue_and_its_articles() {
+		$catalog = $this->empty_catalog();
+		$catalog['current_issue'] = array(
+			'title'    => 'Filosofía Contemporánea: Nuevas Perspectivas',
+			'url'      => 'https://example.org/revista/numeros/vol-1-n-1/',
+			'articles' => array(
+				array(
+					'title' => 'El perro y la dignidad compartida',
+					'url'   => 'https://example.org/revista/articulos/el-perro/',
+				),
+			),
+		);
+
+		$document = Llms_Txt::format_document( $catalog );
+
+		$this->assertStringContainsString( '## Número actual', $document );
+		$this->assertStringContainsString( '[Filosofía Contemporánea: Nuevas Perspectivas](https://example.org/revista/numeros/vol-1-n-1/)', $document );
+		$this->assertStringContainsString( '[El perro y la dignidad compartida](https://example.org/revista/articulos/el-perro/)', $document );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function empty_catalog() {
+		return array(
+			'name'          => 'Revista de Filosofía LOGO ET SPES',
+			'description'   => 'Publicación digital venezolana de acceso abierto.',
+			'home_url'      => 'https://example.org/',
+			'issues_url'    => 'https://example.org/revista/numeros/',
+			'articles_url'  => 'https://example.org/revista/articulos/',
+			'authors_url'   => 'https://example.org/revista/autores/',
+			'sitemap_url'   => 'https://example.org/wp-sitemap.xml',
+			'current_issue' => null,
+		);
+	}
+}

--- a/tests/Unit/LlmsTxtDocumentTest.php
+++ b/tests/Unit/LlmsTxtDocumentTest.php
@@ -67,6 +67,17 @@ class LlmsTxtDocumentTest extends TestCase {
 	}
 
 	/**
+	 * Dado: un valor de ajuste crudo.
+	 * Entonces: solo queda 0 o 1.
+	 */
+	public function test_enable_setting_stores_only_zero_or_one() {
+		$this->assertSame( 1, Llms_Txt::sanitize( 1 ) );
+		$this->assertSame( 1, Llms_Txt::sanitize( '1' ) );
+		$this->assertSame( 0, Llms_Txt::sanitize( 0 ) );
+		$this->assertSame( 0, Llms_Txt::sanitize( 'no' ) );
+	}
+
+	/**
 	 * Dado: un número publicado con artículos.
 	 * Entonces: el documento enlaza ese número y esos artículos.
 	 */

--- a/tests/Unit/LlmsTxtDocumentTest.php
+++ b/tests/Unit/LlmsTxtDocumentTest.php
@@ -27,6 +27,43 @@ class LlmsTxtDocumentTest extends TestCase {
 		$this->assertStringContainsString( 'https://example.org/revista/autores/', $document );
 		$this->assertStringContainsString( 'https://example.org/wp-sitemap.xml', $document );
 		$this->assertStringNotContainsString( 'Número actual', $document );
+		$this->assertStringNotContainsString( 'Información institucional', $document );
+	}
+
+	/**
+	 * Dado: páginas institucionales publicadas.
+	 * Entonces: el documento las enlaza por título y URL, sin inventar otras.
+	 */
+	public function test_document_lists_institutional_pages() {
+		$catalog                      = $this->empty_catalog();
+		$catalog['institutional_pages'] = array(
+			array(
+				'title' => 'Normas de Publicación',
+				'url'   => 'https://example.org/normas/',
+			),
+			array(
+				'title' => 'Ética',
+				'url'   => 'https://example.org/etica/',
+			),
+			array(
+				'title' => 'Políticas',
+				'url'   => 'https://example.org/politicas/',
+			),
+			array(
+				'title' => 'Comité Editorial',
+				'url'   => 'https://example.org/comite-editorial/',
+			),
+		);
+
+		$document = Llms_Txt::format_document( $catalog );
+
+		$this->assertStringContainsString( '## Información institucional', $document );
+		$this->assertStringContainsString( '[Normas de Publicación](https://example.org/normas/)', $document );
+		$this->assertStringContainsString( '[Ética](https://example.org/etica/)', $document );
+		$this->assertStringContainsString( '[Políticas](https://example.org/politicas/)', $document );
+		$this->assertStringContainsString( '[Comité Editorial](https://example.org/comite-editorial/)', $document );
+		$this->assertStringNotContainsString( 'Búsqueda', $document );
+		$this->assertStringNotContainsString( 'lineamientos', $document );
 	}
 
 	/**
@@ -64,8 +101,9 @@ class LlmsTxtDocumentTest extends TestCase {
 			'issues_url'    => 'https://example.org/revista/numeros/',
 			'articles_url'  => 'https://example.org/revista/articulos/',
 			'authors_url'   => 'https://example.org/revista/autores/',
-			'sitemap_url'   => 'https://example.org/wp-sitemap.xml',
-			'current_issue' => null,
+			'sitemap_url'          => 'https://example.org/wp-sitemap.xml',
+			'current_issue'        => null,
+			'institutional_pages'  => array(),
 		);
 	}
 }

--- a/tests/WordPress/LlmsTxtCatalogTest.php
+++ b/tests/WordPress/LlmsTxtCatalogTest.php
@@ -37,6 +37,33 @@ class LlmsTxtCatalogTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'doble anónimo', $document );
 		$this->assertStringContainsString( '/wp-sitemap.xml', $document );
 		$this->assertStringNotContainsString( '## Número actual', $document );
+		$this->assertStringNotContainsString( '## Información institucional', $document );
+	}
+
+	/**
+	 * Dado: páginas institucionales publicadas y un borrador.
+	 * Entonces: /llms.txt enlaza solo las publicadas del mapa estable.
+	 */
+	public function test_render_lists_published_institutional_pages_and_skips_drafts() {
+		$this->make_page( 'normas', 'Normas de Publicación', 'publish' );
+		$this->make_page( 'etica', 'Ética', 'publish' );
+		$this->make_page( 'politicas', 'Políticas', 'publish' );
+		$this->make_page( 'comite-editorial', 'Comité Editorial', 'publish' );
+		$this->make_page( 'acerca', 'Acerca', 'draft' );
+		$this->make_page( 'buscar', 'Búsqueda', 'publish' );
+		$this->make_page( 'pagina-ajena', 'Página ajena', 'publish' );
+
+		$document = Llms_Txt::render();
+
+		$this->assertStringContainsString( '## Información institucional', $document );
+		$this->assertStringContainsString( 'Normas de Publicación', $document );
+		$this->assertStringContainsString( home_url( '/normas/' ), $document );
+		$this->assertStringContainsString( 'Ética', $document );
+		$this->assertStringContainsString( 'Políticas', $document );
+		$this->assertStringContainsString( 'Comité Editorial', $document );
+		$this->assertStringNotContainsString( 'Acerca', $document );
+		$this->assertStringNotContainsString( 'Búsqueda', $document );
+		$this->assertStringNotContainsString( 'Página ajena', $document );
 	}
 
 	/**
@@ -65,6 +92,122 @@ class LlmsTxtCatalogTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Borrador futuro', $document );
 		$this->assertStringNotContainsString( 'Artículo en borrador', $document );
 		$this->assertStringNotContainsString( get_permalink( $draft_article ), $document );
+	}
+
+	/**
+	 * Dado: un número publicado y permalinks sin la regla de /llms.txt.
+	 * Cuando: un administrador actualiza /llms.txt.
+	 * Entonces: el documento refleja ese número y la ruta queda registrada.
+	 */
+	public function test_administrator_refresh_registers_pretty_url_and_returns_current_catalog() {
+		$issue_id  = $this->make_issue( 'Número para actualizar llms', '2026-09-10', 'publish' );
+		$author_id = $this->make_published_author( 'Autora para actualizar llms' );
+		$this->make_article( 'Artículo vivo para llms', $issue_id, 'publish', $author_id );
+
+		delete_option( 'rewrite_rules' );
+
+		$nonce    = wp_create_nonce( Llms_Txt::REFRESH_NONCE );
+		$document = Llms_Txt::refresh_if_authorized( $nonce );
+
+		$this->assertIsString( $document );
+		$this->assertStringContainsString( 'Número para actualizar llms', $document );
+		$this->assertStringContainsString( 'Artículo vivo para llms', $document );
+
+		$rules = get_option( 'rewrite_rules' );
+		$this->assertIsArray( $rules );
+		$this->assertArrayHasKey( '^llms\.txt$', $rules );
+	}
+
+	/**
+	 * Dado: un usuario sin manage_options.
+	 * Entonces: no puede actualizar /llms.txt.
+	 */
+	public function test_refresh_is_denied_without_manage_options() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = Llms_Txt::refresh_if_authorized( wp_create_nonce( Llms_Txt::REFRESH_NONCE ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Dado: un administrador con nonce inválido.
+	 * Entonces: no actualiza /llms.txt.
+	 */
+	public function test_refresh_is_denied_with_invalid_nonce() {
+		$result = Llms_Txt::refresh_if_authorized( 'nonce-invalido' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_nonce', $result->get_error_code() );
+	}
+
+	/**
+	 * Dado: Ajustes → LOGO ET SPES — llms.txt.
+	 * Entonces: la pantalla nombra el plugin, el archivo técnico y
+	 * ofrece Actualizar llms.txt con nonce.
+	 */
+	public function test_settings_page_offers_manual_llms_refresh() {
+		ob_start();
+		Llms_Txt::render_settings_page();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'LOGO ET SPES', $html );
+		$this->assertStringContainsString( '<code>llms.txt</code>', $html );
+		$this->assertStringContainsString( '/llms.txt', $html );
+		$this->assertStringContainsString( 'Actualizar llms.txt', $html );
+		$this->assertStringContainsString( 'name="_wpnonce"', $html );
+		$this->assertStringNotContainsString( 'Mapa para IA', $html );
+		$this->assertStringNotContainsString( 'Índice público', $html );
+	}
+
+	/**
+	 * Dado: el menú Ajustes.
+	 * Entonces: llms.txt cuelga del mismo prefijo que LOGO ET SPES.
+	 */
+	public function test_settings_menu_has_a_separate_llms_txt_entry() {
+		Llms_Txt::register_page();
+		\Revistalogos_Core\Article_Pdf_Publication_Settings::register_page();
+
+		global $submenu;
+		$this->assertArrayHasKey( 'options-general.php', $submenu );
+
+		$slugs  = array();
+		$labels = array();
+		foreach ( $submenu['options-general.php'] as $item ) {
+			$slugs[]            = $item[2];
+			$labels[ $item[2] ] = wp_strip_all_tags( $item[0] );
+		}
+
+		$this->assertContains( Llms_Txt::PAGE_SLUG, $slugs );
+		$this->assertContains( \Revistalogos_Core\Article_Pdf_Publication_Settings::PAGE_SLUG, $slugs );
+		$this->assertNotSame( Llms_Txt::PAGE_SLUG, \Revistalogos_Core\Article_Pdf_Publication_Settings::PAGE_SLUG );
+		$this->assertSame( 'LOGO ET SPES — llms.txt', $labels[ Llms_Txt::PAGE_SLUG ] );
+		$this->assertSame( 'LOGO ET SPES', $labels[ \Revistalogos_Core\Article_Pdf_Publication_Settings::PAGE_SLUG ] );
+	}
+
+	/**
+	 * Dado: Ajustes → LOGO ET SPES (PDF).
+	 * Entonces: no incrusta el panel de llms.txt.
+	 */
+	public function test_pdf_settings_page_does_not_embed_llms_panel() {
+		ob_start();
+		\Revistalogos_Core\Article_Pdf_Publication_Settings::render_page();
+		$html = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'Actualizar llms.txt', $html );
+	}
+
+	/**
+	 * Dado: la fila del plugin en Plugins.
+	 * Entonces: el enlace nombra la pantalla, no finge que actualiza.
+	 */
+	public function test_plugin_row_links_to_the_llms_txt_screen() {
+		$links = Llms_Txt::plugin_action_links( array() );
+
+		$this->assertStringContainsString( '>llms.txt<', implode( ' ', $links ) );
+		$this->assertStringContainsString( 'page=' . Llms_Txt::PAGE_SLUG, implode( ' ', $links ) );
+		$this->assertStringNotContainsString( 'Actualizar llms.txt', implode( ' ', $links ) );
 	}
 
 	/**
@@ -131,5 +274,22 @@ class LlmsTxtCatalogTest extends WP_UnitTestCase {
 		}
 
 		return $article_id;
+	}
+
+	/**
+	 * @param string $slug   Page slug.
+	 * @param string $title  Page title.
+	 * @param string $status Post status.
+	 * @return int
+	 */
+	private function make_page( $slug, $title, $status ) {
+		return (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_name'   => $slug,
+				'post_title'  => $title,
+				'post_status' => $status,
+			)
+		);
 	}
 }

--- a/tests/WordPress/LlmsTxtCatalogTest.php
+++ b/tests/WordPress/LlmsTxtCatalogTest.php
@@ -148,6 +148,8 @@ class LlmsTxtCatalogTest extends WP_UnitTestCase {
 	 * ofrece Actualizar llms.txt con nonce.
 	 */
 	public function test_settings_page_offers_manual_llms_refresh() {
+		Llms_Txt::register_setting();
+
 		ob_start();
 		Llms_Txt::render_settings_page();
 		$html = ob_get_clean();
@@ -156,9 +158,51 @@ class LlmsTxtCatalogTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<code>llms.txt</code>', $html );
 		$this->assertStringContainsString( '/llms.txt', $html );
 		$this->assertStringContainsString( 'Actualizar llms.txt', $html );
+		$this->assertStringContainsString( 'Publicar llms.txt', $html );
+		$this->assertStringContainsString( 'name="' . Llms_Txt::OPTION_NAME . '"', $html );
 		$this->assertStringContainsString( 'name="_wpnonce"', $html );
 		$this->assertStringNotContainsString( 'Mapa para IA', $html );
 		$this->assertStringNotContainsString( 'Índice público', $html );
+	}
+
+	/**
+	 * Dado: la opción no existe.
+	 * Entonces: /llms.txt sigue público (ausencia = activado).
+	 */
+	public function test_missing_option_keeps_llms_txt_enabled() {
+		delete_option( Llms_Txt::OPTION_NAME );
+
+		$this->assertTrue( Llms_Txt::is_enabled() );
+	}
+
+	/**
+	 * Dado: un administrador desactiva llms.txt.
+	 * Entonces: la dirección pública no publica el mapa.
+	 */
+	public function test_disabled_option_stops_public_llms_txt() {
+		$previous_uri           = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '/';
+		$_SERVER['REQUEST_URI'] = '/llms.txt';
+		update_option( Llms_Txt::OPTION_NAME, 0 );
+
+		$this->assertFalse( Llms_Txt::is_enabled() );
+		$this->assertFalse( Llms_Txt::should_serve() );
+
+		$_SERVER['REQUEST_URI'] = $previous_uri;
+	}
+
+	/**
+	 * Dado: llms.txt activado y una petición a esa ruta.
+	 * Entonces: se publica el mapa.
+	 */
+	public function test_enabled_llms_request_should_serve() {
+		$previous_uri           = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '/';
+		$_SERVER['REQUEST_URI'] = '/llms.txt';
+		update_option( Llms_Txt::OPTION_NAME, 1 );
+
+		$this->assertTrue( Llms_Txt::is_enabled() );
+		$this->assertTrue( Llms_Txt::should_serve() );
+
+		$_SERVER['REQUEST_URI'] = $previous_uri;
 	}
 
 	/**

--- a/tests/WordPress/LlmsTxtCatalogTest.php
+++ b/tests/WordPress/LlmsTxtCatalogTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * /llms.txt is generated from published journal objects (issue #47).
+ *
+ * @package Revistalogos
+ */
+
+use Revistalogos_Core\Content_Types;
+use Revistalogos_Core\Llms_Txt;
+use Revistalogos_Core\Roles;
+use Revistalogos_Core\Taxonomies;
+
+/**
+ * Production editorial rows stay in production. These cases invent
+ * published objects in the isolated suite so the file stays dynamic.
+ */
+class LlmsTxtCatalogTest extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		Content_Types::register();
+		Taxonomies::register();
+		Roles::install();
+		$this->set_permalink_structure( '/%postname%/' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Dado: no hay números publicados.
+	 * Entonces: /llms.txt sigue siendo un mapa válido sin inventar un número.
+	 */
+	public function test_render_without_published_issue_has_no_current_issue_heading() {
+		$document = Llms_Txt::render();
+
+		$this->assertStringContainsString( '# Revista de Filosofía LOGO ET SPES', $document );
+		$this->assertStringContainsString( 'Stanislao Strba', $document );
+		$this->assertStringContainsString( 'doble anónimo', $document );
+		$this->assertStringContainsString( '/wp-sitemap.xml', $document );
+		$this->assertStringNotContainsString( '## Número actual', $document );
+	}
+
+	/**
+	 * Dado: un número publicado con artículos, y un borrador.
+	 * Entonces: solo el número vigente y sus artículos publicados aparecen.
+	 */
+	public function test_render_lists_current_published_issue_and_skips_drafts() {
+		$current_id = $this->make_issue( 'Volumen vigente de prueba', '2026-09-01', 'publish' );
+		$this->make_issue( 'Borrador futuro', '2026-12-01', 'draft' );
+
+		$author_id     = $this->make_published_author( 'Autora de prueba' );
+		$live_article  = $this->make_article( 'Artículo publicado del número', $current_id, 'publish', $author_id );
+		$draft_article = $this->make_article( 'Artículo en borrador', $current_id, 'draft' );
+
+		$this->assertSame( 'article', get_post_type( $live_article ) );
+		$this->assertSame( 'publish', get_post_status( $live_article ) );
+		$this->assertSame( (string) $current_id, (string) get_post_meta( $live_article, 'issue', true ) );
+
+		$document = Llms_Txt::render();
+
+		$this->assertStringContainsString( '## Número actual', $document );
+		$this->assertStringContainsString( 'Volumen vigente de prueba', $document );
+		$this->assertStringContainsString( get_permalink( $current_id ), $document );
+		$this->assertStringContainsString( 'Artículo publicado del número', $document );
+		$this->assertStringContainsString( get_permalink( $live_article ), $document );
+		$this->assertStringNotContainsString( 'Borrador futuro', $document );
+		$this->assertStringNotContainsString( 'Artículo en borrador', $document );
+		$this->assertStringNotContainsString( get_permalink( $draft_article ), $document );
+	}
+
+	/**
+	 * @param string $title  Issue title.
+	 * @param string $date   date_published Y-m-d.
+	 * @param string $status Post status.
+	 * @return int
+	 */
+	private function make_issue( $title, $date, $status ) {
+		$issue_id = (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'issue',
+				'post_title'  => $title,
+				'post_status' => $status,
+			)
+		);
+		update_post_meta( $issue_id, 'date_published', $date );
+
+		return $issue_id;
+	}
+
+	/**
+	 * @param string $name Author display name.
+	 * @return int
+	 */
+	private function make_published_author( $name ) {
+		return (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'author',
+				'post_title'  => $name,
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Factory publish of an article is demoted to draft unless a
+	 * published Author CPT is already assigned (plugin 0.2.5).
+	 *
+	 * @param string   $title     Article title.
+	 * @param int      $issue_id  Issue post ID.
+	 * @param string   $status    Desired post status.
+	 * @param int|null $author_id Published Author CPT ID when publishing.
+	 * @return int
+	 */
+	private function make_article( $title, $issue_id, $status, $author_id = null ) {
+		$article_id = (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'article',
+				'post_title'  => $title,
+				'post_status' => 'draft',
+			)
+		);
+		update_post_meta( $article_id, 'issue', $issue_id );
+
+		if ( 'publish' === $status ) {
+			update_post_meta( $article_id, 'authors', array( absint( $author_id ) ) );
+			wp_update_post(
+				array(
+					'ID'          => $article_id,
+					'post_status' => 'publish',
+				)
+			);
+		}
+
+		return $article_id;
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
@@ -50,6 +50,7 @@ class Plugin {
 		Article_Pdf_Publication_Settings::register_hooks();
 		Article_Pdf_Publication_Enforcer::register_hooks();
 		Native_Sitemap::register_hooks();
+		Llms_Txt::register_hooks();
 
 		// Idempotent upgrade: late on init so CPT rewrite args are
 		// registered before a version-gated rewrite flush.
@@ -86,6 +87,7 @@ class Plugin {
 		require_once $includes . 'integrations/class-comments-disabler.php';
 		require_once $includes . 'integrations/class-contact-form-integration.php';
 		require_once $includes . 'integrations/class-native-sitemap.php';
+		require_once $includes . 'integrations/class-llms-txt.php';
 		require_once $includes . 'migration/class-content-migrator.php';
 		require_once $includes . 'fixtures/class-fixtures.php';
 		require_once $includes . 'article-pdf/class-article-pdf-publication-policy.php';

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
@@ -17,8 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Llms_Txt {
 
-	const QUERY_VAR     = 'revistalogos_llms';
+	const QUERY_VAR      = 'revistalogos_llms';
 	const PAGE_SLUG      = 'revistalogos-llms-txt';
+	const OPTION_NAME    = 'revistalogos_llms_txt_enabled';
+	const SETTINGS_GROUP = 'revistalogos_llms_txt';
 	const REFRESH_ACTION = 'revistalogos_refresh_llms_txt';
 	const REFRESH_NONCE  = 'revistalogos_refresh_llms_txt';
 
@@ -57,6 +59,9 @@ class Llms_Txt {
 		add_filter( 'query_vars', array( __CLASS__, 'register_query_var' ) );
 		add_action( 'template_redirect', array( __CLASS__, 'serve' ), 0 );
 		add_action( 'admin_menu', array( __CLASS__, 'register_page' ) );
+		add_action( 'admin_init', array( __CLASS__, 'register_setting' ) );
+		add_action( 'update_option_' . self::OPTION_NAME, array( __CLASS__, 'flush_after_toggle' ) );
+		add_action( 'add_option_' . self::OPTION_NAME, array( __CLASS__, 'flush_after_toggle' ) );
 		add_action( 'admin_post_' . self::REFRESH_ACTION, array( __CLASS__, 'handle_refresh' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'render_refresh_notice' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( REVISTALOGOS_CORE_FILE ), array( __CLASS__, 'plugin_action_links' ) );
@@ -66,6 +71,10 @@ class Llms_Txt {
 	 * Pretty /llms.txt. Flushed by Plugin::maybe_upgrade() on version bump.
 	 */
 	public static function register_rewrite() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
 		add_rewrite_rule( '^llms\.txt$', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
 	}
 
@@ -82,8 +91,47 @@ class Llms_Txt {
 	/**
 	 * Serve text/plain when this is an llms.txt request.
 	 */
+	/**
+	 * Absence of the option is ON. Deploy does not write the option.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return 1 === (int) get_option( self::OPTION_NAME, 1 );
+	}
+
+	/**
+	 * Store only 0 or 1.
+	 *
+	 * @param mixed $value Raw submitted value.
+	 * @return int
+	 */
+	public static function sanitize( $value ) {
+		return ( 1 === (int) $value ) ? 1 : 0;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public static function should_serve() {
+		return self::is_enabled() && self::is_llms_request();
+	}
+
+	/**
+	 * Serve text/plain when this is an enabled llms.txt request.
+	 */
 	public static function serve() {
 		if ( ! self::is_llms_request() ) {
+			return;
+		}
+
+		if ( ! self::is_enabled() ) {
+			global $wp_query;
+			if ( $wp_query instanceof \WP_Query ) {
+				$wp_query->set_404();
+			}
+			status_header( 404 );
+			nocache_headers();
 			return;
 		}
 
@@ -152,8 +200,69 @@ class Llms_Txt {
 
 		echo '<div class="wrap">';
 		echo '<h1>' . esc_html__( 'LOGO ET SPES', 'revistalogos-core' ) . ' — <code>' . esc_html__( 'llms.txt', 'revistalogos-core' ) . '</code></h1>';
+		echo '<form action="options.php" method="post">';
+		settings_fields( self::SETTINGS_GROUP );
+		do_settings_sections( self::PAGE_SLUG );
+		submit_button();
+		echo '</form>';
 		self::render_admin_panel();
 		echo '</div>';
+	}
+
+	/**
+	 * Settings API: publish toggle. Does not write the option.
+	 */
+	public static function register_setting() {
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::OPTION_NAME,
+			array(
+				'type'              => 'integer',
+				'sanitize_callback' => array( __CLASS__, 'sanitize' ),
+				'default'           => 1,
+				'show_in_rest'      => false,
+			)
+		);
+
+		add_settings_section(
+			'revistalogos_llms_txt',
+			'',
+			'__return_false',
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			self::OPTION_NAME,
+			__( 'Publicar llms.txt', 'revistalogos-core' ),
+			array( __CLASS__, 'render_enable_field' ),
+			self::PAGE_SLUG,
+			'revistalogos_llms_txt'
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public static function render_enable_field() {
+		printf(
+			'<input type="hidden" name="%1$s" value="0">',
+			esc_attr( self::OPTION_NAME )
+		);
+		printf(
+			'<label><input type="checkbox" name="%1$s" value="1"%2$s> %3$s</label>',
+			esc_attr( self::OPTION_NAME ),
+			checked( self::is_enabled(), true, false ),
+			esc_html__( 'Publicar llms.txt', 'revistalogos-core' )
+		);
+		echo '<p class="description">' . esc_html__( 'Activada: la dirección pública responde con el índice. Desactivada: /llms.txt no se publica.', 'revistalogos-core' ) . '</p>';
+	}
+
+	/**
+	 * Flush pretty permalinks after the publish toggle changes.
+	 */
+	public static function flush_after_toggle() {
+		self::register_rewrite();
+		flush_rewrite_rules();
 	}
 
 	/**

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
@@ -17,7 +17,27 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Llms_Txt {
 
-	const QUERY_VAR = 'revistalogos_llms';
+	const QUERY_VAR     = 'revistalogos_llms';
+	const PAGE_SLUG      = 'revistalogos-llms-txt';
+	const REFRESH_ACTION = 'revistalogos_refresh_llms_txt';
+	const REFRESH_NONCE  = 'revistalogos_refresh_llms_txt';
+
+	/**
+	 * Published institutional pages (docs/11). No /buscar/ (noindex).
+	 * There is no separate lineamientos or reglamentos page.
+	 */
+	const INSTITUTIONAL_SLUGS = array(
+		'acerca',
+		'normas',
+		'etica',
+		'politicas',
+		'comite-editorial',
+		'enviar-colaboracion',
+		'contacto',
+		'enlaces',
+		'noticias',
+		'privacidad',
+	);
 
 	/**
 	 * Public journal name (content-source / site chrome).
@@ -36,6 +56,10 @@ class Llms_Txt {
 		add_action( 'init', array( __CLASS__, 'register_rewrite' ) );
 		add_filter( 'query_vars', array( __CLASS__, 'register_query_var' ) );
 		add_action( 'template_redirect', array( __CLASS__, 'serve' ), 0 );
+		add_action( 'admin_menu', array( __CLASS__, 'register_page' ) );
+		add_action( 'admin_post_' . self::REFRESH_ACTION, array( __CLASS__, 'handle_refresh' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'render_refresh_notice' ) );
+		add_filter( 'plugin_action_links_' . plugin_basename( REVISTALOGOS_CORE_FILE ), array( __CLASS__, 'plugin_action_links' ) );
 	}
 
 	/**
@@ -78,6 +102,139 @@ class Llms_Txt {
 	}
 
 	/**
+	 * Re-register the pretty URL and return the current catalog.
+	 *
+	 * @return string
+	 */
+	public static function refresh() {
+		self::register_rewrite();
+		flush_rewrite_rules();
+
+		return self::render();
+	}
+
+	/**
+	 * @param string $nonce Submitted nonce.
+	 * @return string|\WP_Error Fresh document, or an authorization error.
+	 */
+	public static function refresh_if_authorized( $nonce ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'forbidden', __( 'No tiene permiso para actualizar llms.txt.', 'revistalogos-core' ) );
+		}
+
+		if ( ! wp_verify_nonce( $nonce, self::REFRESH_NONCE ) ) {
+			return new \WP_Error( 'invalid_nonce', __( 'La solicitud para actualizar llms.txt no es válida.', 'revistalogos-core' ) );
+		}
+
+		return self::refresh();
+	}
+
+	/**
+	 * Settings → LOGO ET SPES — llms.txt. Same plugin prefix as the PDF page.
+	 */
+	public static function register_page() {
+		add_options_page(
+			__( 'LOGO ET SPES — llms.txt', 'revistalogos-core' ),
+			__( 'LOGO ET SPES — llms.txt', 'revistalogos-core' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( __CLASS__, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Dedicated settings screen (nonce + manage_options).
+	 */
+	public static function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'LOGO ET SPES', 'revistalogos-core' ) . ' — <code>' . esc_html__( 'llms.txt', 'revistalogos-core' ) . '</code></h1>';
+		self::render_admin_panel();
+		echo '</div>';
+	}
+
+	/**
+	 * Settings → LOGO ET SPES — llms.txt refresh button.
+	 */
+	public static function handle_refresh() {
+		$nonce  = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- verified in refresh_if_authorized().
+		$result = self::refresh_if_authorized( $nonce );
+
+		if ( is_wp_error( $result ) ) {
+			wp_die( esc_html( $result->get_error_message() ), '', array( 'response' => 403 ) );
+		}
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'           => self::PAGE_SLUG,
+					'llms_refreshed' => '1',
+				),
+				admin_url( 'options-general.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Manual refresh panel on Settings → LOGO ET SPES — llms.txt.
+	 */
+	public static function render_admin_panel() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$public_url = home_url( '/llms.txt' );
+
+		echo '<div class="card" id="llms-txt" style="max-width:800px;margin-top:1.5em;padding:1em 1.5em">';
+		echo '<p>' . esc_html__( 'Reúne los archivos vivos y las páginas institucionales publicadas. La dirección pública es /llms.txt.', 'revistalogos-core' ) . '</p>';
+		echo '<p><a href="' . esc_url( $public_url ) . '">' . esc_html( $public_url ) . '</a></p>';
+		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
+		echo '<input type="hidden" name="action" value="' . esc_attr( self::REFRESH_ACTION ) . '">';
+		wp_nonce_field( self::REFRESH_NONCE );
+		submit_button( __( 'Actualizar llms.txt', 'revistalogos-core' ), 'secondary', 'submit', false );
+		echo '</form>';
+		echo '<pre style="white-space:pre-wrap;max-height:22em;overflow:auto;background:#f6f7f7;padding:1em">' . esc_html( self::render() ) . '</pre>';
+		echo '</div>';
+	}
+
+	/**
+	 * Success notice after a manual refresh.
+	 */
+	public static function render_refresh_notice() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( empty( $_GET['page'] ) || self::PAGE_SLUG !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only admin screen flag.
+			return;
+		}
+
+		if ( empty( $_GET['llms_refreshed'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only admin screen flag.
+			return;
+		}
+
+		echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'llms.txt se actualizó. La dirección pública vuelve a estar registrada.', 'revistalogos-core' ) . '</p></div>';
+	}
+
+	/**
+	 * @param string[] $links Plugin row actions.
+	 * @return string[]
+	 */
+	public static function plugin_action_links( $links ) {
+		$links[] = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( admin_url( 'options-general.php?page=' . self::PAGE_SLUG ) ),
+			'<code>' . esc_html__( 'llms.txt', 'revistalogos-core' ) . '</code>'
+		);
+
+		return $links;
+	}
+
+	/**
 	 * @param array<string, mixed> $catalog Prepared public catalog.
 	 * @return string
 	 */
@@ -95,6 +252,21 @@ class Llms_Txt {
 		$lines[] = '- [Artículos](' . $catalog['articles_url'] . ')';
 		$lines[] = '- [Autores](' . $catalog['authors_url'] . ')';
 		$lines[] = '';
+
+		if ( ! empty( $catalog['institutional_pages'] ) && is_array( $catalog['institutional_pages'] ) ) {
+			$lines[] = '## Información institucional';
+			$lines[] = '';
+
+			foreach ( $catalog['institutional_pages'] as $page ) {
+				if ( empty( $page['title'] ) || empty( $page['url'] ) ) {
+					continue;
+				}
+
+				$lines[] = '- [' . $page['title'] . '](' . $page['url'] . ')';
+			}
+
+			$lines[] = '';
+		}
 
 		if ( ! empty( $catalog['current_issue'] ) && is_array( $catalog['current_issue'] ) ) {
 			$issue   = $catalog['current_issue'];
@@ -160,14 +332,37 @@ class Llms_Txt {
 		}
 
 		return array(
-			'name'          => self::JOURNAL_NAME,
-			'description'   => self::JOURNAL_DESCRIPTION,
-			'home_url'      => home_url( '/' ),
-			'issues_url'    => get_post_type_archive_link( Content_Types::ISSUE ) ?: home_url( '/revista/numeros/' ),
-			'articles_url'  => get_post_type_archive_link( Content_Types::ARTICLE ) ?: home_url( '/revista/articulos/' ),
-			'authors_url'   => get_post_type_archive_link( Content_Types::AUTHOR ) ?: home_url( '/revista/autores/' ),
-			'sitemap_url'   => home_url( '/wp-sitemap.xml' ),
-			'current_issue' => $issue,
+			'name'                 => self::JOURNAL_NAME,
+			'description'          => self::JOURNAL_DESCRIPTION,
+			'home_url'             => home_url( '/' ),
+			'issues_url'           => get_post_type_archive_link( Content_Types::ISSUE ) ?: home_url( '/revista/numeros/' ),
+			'articles_url'         => get_post_type_archive_link( Content_Types::ARTICLE ) ?: home_url( '/revista/articulos/' ),
+			'authors_url'          => get_post_type_archive_link( Content_Types::AUTHOR ) ?: home_url( '/revista/autores/' ),
+			'sitemap_url'          => home_url( '/wp-sitemap.xml' ),
+			'current_issue'        => $issue,
+			'institutional_pages'  => self::published_institutional_pages(),
 		);
+	}
+
+	/**
+	 * @return array<int, array{title: string, url: string}>
+	 */
+	private static function published_institutional_pages() {
+		$pages = array();
+
+		foreach ( self::INSTITUTIONAL_SLUGS as $slug ) {
+			$page = get_page_by_path( $slug );
+
+			if ( ! $page instanceof \WP_Post || 'publish' !== $page->post_status ) {
+				continue;
+			}
+
+			$pages[] = array(
+				'title' => get_the_title( $page ),
+				'url'   => get_permalink( $page ),
+			);
+		}
+
+		return $pages;
 	}
 }

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * /llms.txt for AI agents (issue #47). Stable map plus the current
+ * published issue from Queries — never a hardcoded catalog.
+ *
+ * @package Revistalogos_Core
+ */
+
+namespace Revistalogos_Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Renders and serves text/plain /llms.txt.
+ */
+class Llms_Txt {
+
+	const QUERY_VAR = 'revistalogos_llms';
+
+	/**
+	 * Public journal name (content-source / site chrome).
+	 */
+	const JOURNAL_NAME = 'Revista de Filosofía LOGO ET SPES';
+
+	/**
+	 * Hero description — same wording as front-page.php.
+	 */
+	const JOURNAL_DESCRIPTION = 'La Revista de Filosofía adscrita, auspiciada y editada por el Centro de Filosofía para la Investigación <Stanislao Strba> - CENFISS, es una publicación digital venezolana enfocada en el pensamiento filosófico multidisciplinar. Es de acceso abierto; arbitrada bajo la modalidad <doble anónimo o doble ciego>; con periodicidad anual. Sus páginas están disponibles para difundir investigaciones originales -de autores nacionales e internacionales- que coadyuven a promover el desarrollo de todas las áreas de la Filosofía.';
+
+	/**
+	 * Wire rewrite and serving. Called from Plugin::boot().
+	 */
+	public static function register_hooks() {
+		add_action( 'init', array( __CLASS__, 'register_rewrite' ) );
+		add_filter( 'query_vars', array( __CLASS__, 'register_query_var' ) );
+		add_action( 'template_redirect', array( __CLASS__, 'serve' ), 0 );
+	}
+
+	/**
+	 * Pretty /llms.txt. Flushed by Plugin::maybe_upgrade() on version bump.
+	 */
+	public static function register_rewrite() {
+		add_rewrite_rule( '^llms\.txt$', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
+	}
+
+	/**
+	 * @param string[] $vars Public query vars.
+	 * @return string[]
+	 */
+	public static function register_query_var( $vars ) {
+		$vars[] = self::QUERY_VAR;
+
+		return $vars;
+	}
+
+	/**
+	 * Serve text/plain when this is an llms.txt request.
+	 */
+	public static function serve() {
+		if ( ! self::is_llms_request() ) {
+			return;
+		}
+
+		nocache_headers();
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		status_header( 200 );
+		echo self::render(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain map, values from titles/URLs we control.
+		exit;
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function render() {
+		return self::format_document( self::catalog() );
+	}
+
+	/**
+	 * @param array<string, mixed> $catalog Prepared public catalog.
+	 * @return string
+	 */
+	public static function format_document( array $catalog ) {
+		$lines   = array();
+		$lines[] = '# ' . $catalog['name'];
+		$lines[] = '';
+		$lines[] = '> ' . $catalog['description'];
+		$lines[] = '';
+		$lines[] = 'Sitio: ' . $catalog['home_url'];
+		$lines[] = '';
+		$lines[] = '## Contenido vivo';
+		$lines[] = '';
+		$lines[] = '- [Números](' . $catalog['issues_url'] . ')';
+		$lines[] = '- [Artículos](' . $catalog['articles_url'] . ')';
+		$lines[] = '- [Autores](' . $catalog['authors_url'] . ')';
+		$lines[] = '';
+
+		if ( ! empty( $catalog['current_issue'] ) && is_array( $catalog['current_issue'] ) ) {
+			$issue   = $catalog['current_issue'];
+			$lines[] = '## Número actual';
+			$lines[] = '';
+			$lines[] = '- [' . $issue['title'] . '](' . $issue['url'] . ')';
+
+			if ( ! empty( $issue['articles'] ) && is_array( $issue['articles'] ) ) {
+				foreach ( $issue['articles'] as $article ) {
+					$lines[] = '  - [' . $article['title'] . '](' . $article['url'] . ')';
+				}
+			}
+
+			$lines[] = '';
+		}
+
+		$lines[] = '## Sitemap';
+		$lines[] = '';
+		$lines[] = $catalog['sitemap_url'];
+		$lines[] = '';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * @return bool
+	 */
+	private static function is_llms_request() {
+		if ( 1 === (int) get_query_var( self::QUERY_VAR ) ) {
+			return true;
+		}
+
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+
+		$path = wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH );
+
+		return is_string( $path ) && '/llms.txt' === untrailingslashit( $path );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function catalog() {
+		$current = Queries::current_issue();
+		$issue   = null;
+
+		if ( $current instanceof \WP_Post ) {
+			$articles = array();
+			foreach ( Queries::issue_articles( $current->ID ) as $article ) {
+				$articles[] = array(
+					'title' => get_the_title( $article ),
+					'url'   => get_permalink( $article ),
+				);
+			}
+
+			$issue = array(
+				'title'    => get_the_title( $current ),
+				'url'      => get_permalink( $current ),
+				'articles' => $articles,
+			);
+		}
+
+		return array(
+			'name'          => self::JOURNAL_NAME,
+			'description'   => self::JOURNAL_DESCRIPTION,
+			'home_url'      => home_url( '/' ),
+			'issues_url'    => get_post_type_archive_link( Content_Types::ISSUE ) ?: home_url( '/revista/numeros/' ),
+			'articles_url'  => get_post_type_archive_link( Content_Types::ARTICLE ) ?: home_url( '/revista/articulos/' ),
+			'authors_url'   => get_post_type_archive_link( Content_Types::AUTHOR ) ?: home_url( '/revista/autores/' ),
+			'sitemap_url'   => home_url( '/wp-sitemap.xml' ),
+			'current_issue' => $issue,
+		);
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -3,7 +3,7 @@ Contributors: cenfiss
 Requires at least: 6.4
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 0.2.11
+Stable tag: 0.2.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,11 @@ Fase 3: los campos `issn`, `doi` y `orcid` son almacenamiento base inerte;
 la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 == Changelog ==
+
+= 0.2.12 =
+* Serve `/llms.txt` for AI agents (issue #47): stable archive map plus
+  the current published issue and its articles from `Queries`. No
+  SiteSEO and no hardcoded catalog.
 
 = 0.2.11 =
 * Native sitemap: drop the `users` provider, exclude `/buscar/` from the

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -40,7 +40,8 @@ la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 = 0.2.12 =
 * Serve `/llms.txt` for AI agents (issue #47): stable archive map plus
-  the current published issue and its articles from `Queries`. No
+  the current published issue and its articles from `Queries`. An
+  administrator can refresh it from Settings → LOGO ET SPES — llms.txt. No
   SiteSEO and no hardcoded catalog.
 
 = 0.2.11 =

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -41,7 +41,8 @@ la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 = 0.2.12 =
 * Serve `/llms.txt` for AI agents (issue #47): stable archive map plus
   the current published issue and its articles from `Queries`. An
-  administrator can refresh it from Settings → LOGO ET SPES — llms.txt. No
+  administrator can enable, disable or refresh it from Settings →
+  LOGO ET SPES — llms.txt (missing option = on). No
   SiteSEO and no hardcoded catalog.
 
 = 0.2.11 =

--- a/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Revista LOGO ET SPES — Core
  * Plugin URI:        https://github.com/refo44/demo-revistalogos
  * Description:       Modelo de contenido de la Revista de Filosofía LOGO ET SPES: números, artículos, autores, taxonomías, rol Managing Editor, migración de contenido institucional y fixtures. El theme revistalogos solo presenta; este plugin es el dueño del dominio (ADR 0005).
- * Version:           0.2.11
+ * Version:           0.2.12
  * Requires at least: 6.4
  * Tested up to:      7.1
  * Requires PHP:      7.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_CORE_VERSION', '0.2.11' );
+define( 'REVISTALOGOS_CORE_VERSION', '0.2.12' );
 define( 'REVISTALOGOS_CORE_FILE', __FILE__ );
 define( 'REVISTALOGOS_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'REVISTALOGOS_CORE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- Serve a dynamic `/llms.txt` from `revistalogos-core` 0.2.12 (issue #47): stable archive map, current published issue, and published institutional pages. No physical file, no SiteSEO, no `llms-full.txt`.
- Administrators can enable, disable, refresh permalinks, and preview the document from Settings → LOGO ET SPES — `llms.txt` (nonce + `manage_options`). Missing option = enabled. Disabled `/llms.txt` is 404.
- Coverage: `tests/Unit/LlmsTxtDocumentTest`, `tests/WordPress/LlmsTxtCatalogTest`, `tests/Features/llms-txt-aeo.feature`.
- Branch includes current `origin/main` (`chore(deps): bump js-yaml` #46).

Closes #47.

## Test plan
- [ ] `composer test` (lint, audit, units including `LlmsTxtDocumentTest`)
- [ ] `composer test:wp` / filter `LlmsTxtCatalogTest`
- [ ] Local Docker: `http://localhost:8080/llms.txt` is `text/plain` 200 and lists archives, institutional pages, and the current issue
- [ ] Draft institutional pages and `/buscar/` do not appear
- [ ] Settings → LOGO ET SPES — `llms.txt`: **Publicar llms.txt** off → public URL 404; on → 200
- [ ] **Actualizar llms.txt** re-registers the pretty URL; preview still visible when disabled
- [ ] Settings → LOGO ET SPES (PDF) does not embed that panel
- [ ] Subscriber cannot refresh