### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.4] — 2026-09-10
+
+Release etiquetado para FTPS de producción (ADR 0020). Incluye
+`/llms.txt` ([#47](https://github.com/refo44/demo-revistalogos/issues/47)
+/[#48](https://github.com/refo44/demo-revistalogos/pull/48), plugin
+`revistalogos-core` **0.2.12**) y el resto de `main` acumulado desde
+`v0.3.3`. Theme sin cambio.
+
 ### Added
 - Plugin `revistalogos-core` 0.2.12: `/llms.txt` generado en cada
   petición (issue #47). Mapa estable de archivos + número actual y

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.3**
+**Versión vigente: 0.3.4**
 
 ## Fuente de verdad
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",


### PR DESCRIPTION
## Summary
- Bump project version to **0.3.4** (`package.json`, `package-lock.json`, `VERSION.md`).
- Move `/llms.txt` (plugin `revistalogos-core` **0.2.12**, #47 / #48) from `[Sin publicar]` into `CHANGELOG.md` `[0.3.4]`.
- Theme unchanged. Plugin version already 0.2.12 on `main`.

After merge, tag the release commit on `main`:

```bash
git fetch --tags origin main
git tag -a v0.3.4 -m "v0.3.4" origin/main
git push origin v0.3.4
```

Then dispatch **Deploy WordPress theme+plugin to production** from tag `v0.3.4` (not from `main`).

## Test plan
- [ ] `package.json` version is `0.3.4`
- [ ] Plugin header / `REVISTALOGOS_CORE_VERSION` / Stable tag stay `0.2.12`
- [ ] After merge, annotated tag `v0.3.4` points at that commit on `main`
- [ ] `./tools/require-production-release-tag.sh` passes on the tagged commit


Made with [Cursor](https://cursor.com)