### PR TITLE
fix(theme): emit crawlable site preview for social cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+### Added
+- Plugin `revistalogos-core` 0.2.13: `/llms.txt` incluye la Page
+  `donaciones` cuando está publicada. El contenido de pago sigue en
+  wp-admin; no hay plantilla de theme. Mapa: `docs/04`.
+
+### Fixed
+- Theme `revistalogos` 0.2.3: la portada emite `og:image` (con
+  ancho/alto), `twitter:card` / `twitter:image` y `Periodical.image`
+  con el logo de la revista. X y WhatsApp no mostraban tarjeta: el
+  theme solo declaraba imagen en singular con destacada, y la ruta
+  estática `/assets/img/logo-revista.png` es 404. Facebook/Threads
+  sí raspaban otra imagen de la página.
+
 ### Changed
 - `deploy-wordpress.yml` y `tools/require-production-release-tag.sh`
   rechazan un `workflow_dispatch` desde `main` (o cualquier rama)

--- a/docs/04-screen-map.md
+++ b/docs/04-screen-map.md
@@ -20,6 +20,7 @@ Lista de las pantallas que existen en el sitio. No describe diseño visual; solo
 | Enviar colaboración | Instrucciones para autores, formularios, CTA principal para envío. |
 | Comité Editorial | Consejo Editorial, Editor General, Editores adjuntos, Árbitros. |
 | Enlaces | Enlaces de interés, CENFISS, partners. |
+| Donaciones | Vías de apoyo a la revista (Pago Móvil, Zelle, PayPal). Contenido editorial en la Page de WordPress; plantilla `page.php`. |
 
 ---
 

--- a/docs/05-information-architecture-navigation.md
+++ b/docs/05-information-architecture-navigation.md
@@ -35,6 +35,7 @@ Este documento define qué enlaces salen de cada pantalla, a dónde van, en qué
 | Enviar colaboración | Página de envío |
 | Noticias | Índice del blog |
 | Acerca | Página Acerca |
+| Donaciones | Página Donaciones |
 | Contacto | Página de contacto |
 | CENFISS ↗ | cenfiss.net (externo) |
 
@@ -59,6 +60,7 @@ Este documento define qué enlaces salen de cada pantalla, a dónde van, en qué
 | Ética editorial | Página Ética |
 | Políticas | Página Políticas |
 | Comité editorial | Página Comité |
+| Donaciones | Página Donaciones |
 | Contacto | Página de contacto, web CENFISS, email |
 | Licencia Creative Commons | Licencia CC (externo) |
 | Privacidad | Página de privacidad |
@@ -79,6 +81,7 @@ Este documento define qué enlaces salen de cada pantalla, a dónde van, en qué
 | Normas | Descargas PDF, enlaces APA/Vancouver | Políticas, Enviar colaboración |
 | Políticas | — | Normas, Enviar colaboración |
 | Acerca | — | Enviar colaboración, Contacto |
+| Donaciones | Vías de pago publicadas en la Page | Contacto |
 | Contacto | mailto, web CENFISS | Enviar colaboración |
 | Comité | — | Enviar colaboración, Normas |
 | Enlaces | Enlaces externos (CENFISS, partners) | Contacto |

--- a/tests/Features/llms-txt-aeo.feature
+++ b/tests/Features/llms-txt-aeo.feature
@@ -26,7 +26,7 @@ Característica: /llms.txt para agentes de IA
     Y la ruta /llms.txt queda registrada
 
   Escenario: Las páginas institucionales publicadas entran en el mapa
-    Dado páginas publicadas de normas, ética, políticas y comité
+    Dado páginas publicadas de normas, ética, políticas, comité y donaciones
     Y una página institucional en borrador
     Cuando se genera /llms.txt
     Entonces enlaza esas páginas publicadas con su título vigente

--- a/tests/Features/site-preview-image.feature
+++ b/tests/Features/site-preview-image.feature
@@ -1,0 +1,22 @@
+# language: es
+Característica: Imagen de preview del sitio
+  Como revista académica
+  quiero que la portada declare una imagen de preview canónica
+  para que Google Search Console y las tarjetas sociales puedan indexarla
+  # Ejecutan: tests/WordPress/SitePreviewImageTest (composer test:wp).
+  # La maqueta estática usaba /assets/img/logo-revista.png; esa ruta
+  # ya no existe en WordPress (404). El fallback es el logo del theme.
+
+  Escenario: La portada sin imagen destacada usa el logo de la revista
+    Dado que la portada es una página sin imagen destacada
+    Cuando se emiten los metadatos del documento
+    Entonces og:image apunta al logo de la revista
+    Y twitter:image es la misma URL
+    Y twitter:card es summary_large_image
+    Y el JSON-LD de Periodical incluye esa misma imagen
+
+  Escenario: Una entrada con imagen destacada no sustituye la propia
+    Dado un contenido singular con imagen destacada
+    Cuando se emiten los metadatos del documento
+    Entonces og:image es la imagen destacada
+    Y twitter:image es esa misma imagen

--- a/tests/WordPress/LlmsTxtCatalogTest.php
+++ b/tests/WordPress/LlmsTxtCatalogTest.php
@@ -49,6 +49,7 @@ class LlmsTxtCatalogTest extends WP_UnitTestCase {
 		$this->make_page( 'etica', 'Ética', 'publish' );
 		$this->make_page( 'politicas', 'Políticas', 'publish' );
 		$this->make_page( 'comite-editorial', 'Comité Editorial', 'publish' );
+		$this->make_page( 'donaciones', 'Donaciones', 'publish' );
 		$this->make_page( 'acerca', 'Acerca', 'draft' );
 		$this->make_page( 'buscar', 'Búsqueda', 'publish' );
 		$this->make_page( 'pagina-ajena', 'Página ajena', 'publish' );
@@ -61,6 +62,8 @@ class LlmsTxtCatalogTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Ética', $document );
 		$this->assertStringContainsString( 'Políticas', $document );
 		$this->assertStringContainsString( 'Comité Editorial', $document );
+		$this->assertStringContainsString( 'Donaciones', $document );
+		$this->assertStringContainsString( home_url( '/donaciones/' ), $document );
 		$this->assertStringNotContainsString( 'Acerca', $document );
 		$this->assertStringNotContainsString( 'Búsqueda', $document );
 		$this->assertStringNotContainsString( 'Página ajena', $document );

--- a/tests/WordPress/SitePreviewImageTest.php
+++ b/tests/WordPress/SitePreviewImageTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Site preview image for Google / Open Graph (homepage fallback to
+ * the journal logo; featured image wins on singular views).
+ *
+ * @package Revistalogos
+ */
+
+require_once dirname( __DIR__, 2 ) . '/wordpress/wp-content/themes/revistalogos/inc/metadata-output.php';
+
+/**
+ * Protects the discoverable preview image that Search Console reads
+ * from the front page. The static URL /assets/img/logo-revista.png
+ * is a 404 on WordPress; the theme logo is the replacement.
+ */
+class SitePreviewImageTest extends WP_UnitTestCase {
+
+	/**
+	 * Dado: la portada es una página sin imagen destacada.
+	 * Cuando: se emiten los metadatos del documento.
+	 * Entonces: og:image apunta al logo de la revista.
+	 */
+	public function test_front_page_without_featured_image_emits_journal_logo_as_og_image() {
+		$this->make_static_front_page();
+
+		$this->go_to( home_url( '/' ) );
+
+		$this->assertTrue( is_front_page() );
+		$this->assertFalse( has_post_thumbnail() );
+
+		$html = $this->render_head_metadata();
+		$logo = $this->journal_logo_url();
+
+		$this->assertStringContainsString( 'property="og:image"', $html );
+		$this->assertStringContainsString( $logo, $html );
+		$this->assertStringContainsString( 'name="twitter:card"', $html );
+		$this->assertStringContainsString( 'summary_large_image', $html );
+		$this->assertStringContainsString( 'name="twitter:image"', $html );
+		$this->assertSame( 2, substr_count( $html, $logo ) );
+	}
+
+	/**
+	 * Dado: la portada sin imagen destacada.
+	 * Entonces: el Periodical JSON-LD declara la misma imagen.
+	 */
+	public function test_front_page_schema_includes_journal_logo() {
+		$this->make_static_front_page();
+
+		$this->go_to( home_url( '/' ) );
+
+		$html   = $this->render_schema_metadata();
+		$schema = $this->json_ld_from( $html );
+
+		$this->assertSame( 'Periodical', $schema['@graph'][0]['@type'] );
+		$this->assertSame( $this->journal_logo_url(), $schema['@graph'][0]['image'] );
+	}
+
+	/**
+	 * Dado: un contenido singular con imagen destacada.
+	 * Entonces: og:image es esa imagen, no el logo.
+	 */
+	public function test_singular_with_featured_image_emits_that_image() {
+		$page_id       = $this->make_published_page( 'normas', 'Normas' );
+		$attachment_id = $this->make_image_attachment( $page_id, 'portada-preview' );
+		set_post_thumbnail( $page_id, $attachment_id );
+
+		$this->go_to( get_permalink( $page_id ) );
+
+		$html     = $this->render_head_metadata();
+		$featured = wp_get_attachment_image_url( $attachment_id, 'full' );
+
+		$this->assertNotEmpty( $featured );
+		$this->assertStringContainsString( 'property="og:image"', $html );
+		$this->assertStringContainsString( 'name="twitter:image"', $html );
+		$this->assertStringContainsString( $featured, $html );
+		$this->assertStringNotContainsString( $this->journal_logo_url(), $html );
+	}
+
+	/**
+	 * @return string Absolute theme-logo URL Search Console should fetch.
+	 */
+	private function journal_logo_url() {
+		return get_theme_root_uri() . '/revistalogos/assets/img/logo-revista.png';
+	}
+
+	/**
+	 * @return void
+	 */
+	private function make_static_front_page() {
+		$front_id = $this->make_published_page( 'inicio', 'Inicio' );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $front_id );
+	}
+
+	/**
+	 * @param string $slug  Page slug.
+	 * @param string $title Page title.
+	 * @return int
+	 */
+	private function make_published_page( $slug, $title ) {
+		return (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_name'   => $slug,
+				'post_title'  => $title,
+			)
+		);
+	}
+
+	/**
+	 * @param int    $parent_id Parent post ID.
+	 * @param string $slug      Filename stem.
+	 * @return int
+	 */
+	private function make_image_attachment( $parent_id, $slug ) {
+		$logo   = get_theme_root() . '/revistalogos/assets/img/logo-revista.png';
+		$binary = file_get_contents( $logo );
+		$this->assertNotFalse( $binary );
+
+		$upload = wp_upload_bits( $slug . '.png', null, $binary );
+		$this->assertEmpty( $upload['error'] ?? '', wp_json_encode( $upload ) );
+
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_mime_type' => 'image/png',
+				'post_title'     => $slug,
+				'post_status'    => 'inherit',
+				'post_parent'    => (int) $parent_id,
+			),
+			$upload['file'],
+			(int) $parent_id
+		);
+		$this->assertFalse( is_wp_error( $attachment_id ) );
+		$this->assertGreaterThan( 0, (int) $attachment_id );
+
+		return (int) $attachment_id;
+	}
+
+	/**
+	 * @return string
+	 */
+	private function render_head_metadata() {
+		ob_start();
+		revistalogos_head_metadata();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @return string
+	 */
+	private function render_schema_metadata() {
+		ob_start();
+		revistalogos_schema_metadata();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @param string $html Document fragment with JSON-LD.
+	 * @return array<string, mixed>
+	 */
+	private function json_ld_from( $html ) {
+		$this->assertSame( 1, preg_match( '/<script type="application\/ld\+json">(.+)<\/script>/s', $html, $matches ) );
+		$schema = json_decode( $matches[1], true );
+		$this->assertIsArray( $schema );
+		return $schema;
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
@@ -36,6 +36,7 @@ class Llms_Txt {
 		'comite-editorial',
 		'enviar-colaboracion',
 		'contacto',
+		'donaciones',
 		'enlaces',
 		'noticias',
 		'privacidad',

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -3,7 +3,7 @@ Contributors: cenfiss
 Requires at least: 6.4
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 0.2.12
+Stable tag: 0.2.13
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,10 @@ Fase 3: los campos `issn`, `doi` y `orcid` son almacenamiento base inerte;
 la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 == Changelog ==
+
+= 0.2.13 =
+* `/llms.txt` lists the published `donaciones` Page. Payment details
+  stay in wp-admin; no theme template.
 
 = 0.2.12 =
 * Serve `/llms.txt` for AI agents (issue #47): stable archive map plus

--- a/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Revista LOGO ET SPES — Core
  * Plugin URI:        https://github.com/refo44/demo-revistalogos
  * Description:       Modelo de contenido de la Revista de Filosofía LOGO ET SPES: números, artículos, autores, taxonomías, rol Managing Editor, migración de contenido institucional y fixtures. El theme revistalogos solo presenta; este plugin es el dueño del dominio (ADR 0005).
- * Version:           0.2.12
+ * Version:           0.2.13
  * Requires at least: 6.4
  * Tested up to:      7.1
  * Requires PHP:      7.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_CORE_VERSION', '0.2.12' );
+define( 'REVISTALOGOS_CORE_VERSION', '0.2.13' );
 define( 'REVISTALOGOS_CORE_FILE', __FILE__ );
 define( 'REVISTALOGOS_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'REVISTALOGOS_CORE_URL', plugin_dir_url( __FILE__ ) );

--- a/wordpress/wp-content/themes/revistalogos/functions.php
+++ b/wordpress/wp-content/themes/revistalogos/functions.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_THEME_VERSION', '0.2.1' );
+define( 'REVISTALOGOS_THEME_VERSION', '0.2.3' );
 
 require_once get_template_directory() . '/inc/template-tags.php';
 require_once get_template_directory() . '/inc/class-nav-walker.php';

--- a/wordpress/wp-content/themes/revistalogos/inc/metadata-output.php
+++ b/wordpress/wp-content/themes/revistalogos/inc/metadata-output.php
@@ -57,11 +57,15 @@ function revistalogos_head_metadata() {
 		printf( '<meta property="og:url" content="%s">' . "\n", esc_url( $og_url ) );
 	}
 
-	if ( is_singular() && has_post_thumbnail() ) {
-		$image = wp_get_attachment_image_url( get_post_thumbnail_id(), 'large' );
-		if ( $image ) {
-			printf( '<meta property="og:image" content="%s">' . "\n", esc_url( $image ) );
+	$preview = revistalogos_preview_image();
+	if ( ! empty( $preview['url'] ) ) {
+		printf( '<meta property="og:image" content="%s">' . "\n", esc_url( $preview['url'] ) );
+		if ( ! empty( $preview['width'] ) && ! empty( $preview['height'] ) ) {
+			printf( '<meta property="og:image:width" content="%d">' . "\n", (int) $preview['width'] );
+			printf( '<meta property="og:image:height" content="%d">' . "\n", (int) $preview['height'] );
 		}
+		printf( '<meta name="twitter:card" content="summary_large_image">' . "\n" );
+		printf( '<meta name="twitter:image" content="%s">' . "\n", esc_url( $preview['url'] ) );
 	}
 
 	// Core emits rel=canonical for singular views only; cover the front
@@ -158,6 +162,7 @@ function revistalogos_schema_metadata() {
 					'@type' => 'Periodical',
 					'name'  => 'Revista de Filosofía LOGO ET SPES',
 					'url'   => home_url( '/' ),
+					'image' => revistalogos_journal_logo_url(),
 					'inLanguage' => 'es',
 					'publisher'  => array(
 						'@type' => 'Organization',
@@ -248,3 +253,51 @@ function revistalogos_schema_metadata() {
 	}
 }
 add_action( 'wp_head', 'revistalogos_schema_metadata', 7 );
+
+/**
+ * Absolute URL of the journal logo used as the site preview image.
+ * Replaces the retired static path /assets/img/logo-revista.png (404).
+ *
+ * @return string
+ */
+function revistalogos_journal_logo_url() {
+	return get_theme_root_uri() . '/revistalogos/assets/img/logo-revista.png';
+}
+
+/**
+ * Preview image for Open Graph and Twitter Cards: featured image on
+ * singular views, otherwise the journal logo. WhatsApp reads og:image;
+ * X requires twitter:card + twitter:image. Facebook/Threads can scrape
+ * in-page images and so appeared to work without these tags.
+ *
+ * @return array{url: string, width: int, height: int}
+ */
+function revistalogos_preview_image() {
+	if ( is_singular() && has_post_thumbnail() ) {
+		$src = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
+		if ( is_array( $src ) && ! empty( $src[0] ) ) {
+			return array(
+				'url'    => $src[0],
+				'width'  => (int) $src[1],
+				'height' => (int) $src[2],
+			);
+		}
+	}
+
+	return array(
+		'url'    => revistalogos_journal_logo_url(),
+		'width'  => 1024,
+		'height' => 1024,
+	);
+}
+
+/**
+ * Absolute URL of the current preview image.
+ *
+ * @return string
+ */
+function revistalogos_preview_image_url() {
+	$preview = revistalogos_preview_image();
+
+	return $preview['url'];
+}

--- a/wordpress/wp-content/themes/revistalogos/style.css
+++ b/wordpress/wp-content/themes/revistalogos/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/refo44/demo-revistalogos
 Author: CENFISS
 Author URI: https://cenfiss.net
 Description: Theme clásico de la Revista de Filosofía LOGO ET SPES. Adaptación sin rediseño de la maqueta estática validada (ADR 0001/0002); todo el CSS vive en assets/css/main.css y sus módulos (ADR 0003). El dominio de contenido lo define el plugin revistalogos-core.
-Version: 0.2.2
+Version: 0.2.3
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4


### PR DESCRIPTION
## Summary
- The live home page had title and `og:url` but no `og:image` or Twitter Card, so X, WhatsApp and Search Console showed no preview. Facebook/Threads still worked because they scrape in-page images.
- The theme now falls back to the journal logo (`logo-revista.png`) and emits `og:image` (with size), `twitter:card` / `twitter:image`, and `Periodical.image`. A featured image still wins on singular views.
- `/llms.txt` lists the published `donaciones` Page. Payment details stay in wp-admin; no theme template. Screen map and IA docs record the page.

Theme `revistalogos` **0.2.3**. Plugin `revistalogos-core` **0.2.13**. Production does not change until a tagged release (ADR 0020).

## Test plan
- [ ] `./tools/run-phpunit-wp.sh tests/WordPress/SitePreviewImageTest.php tests/WordPress/LlmsTxtCatalogTest.php`
- [ ] Local home `<head>` has `og:image`, `twitter:card=summary_large_image`, and `twitter:image` pointing at the theme logo
- [ ] Local `/llms.txt` lists Donaciones when that Page is published
- [ ] After a future tagged FTPS: inspect `https://logo-et-spes.cenfiss.net/` (not the retired `/assets/img/logo-revista.png` 404)
- [ ] After deploy, re-share the URL on X and WhatsApp (both cache cards; WhatsApp may need `?v=2` once)


Made with [Cursor](https://cursor.com)