### PR TITLE
fix(theme): use summary card for square x preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.6] — 2026-09-10
+
+Release etiquetado para FTPS de producción (ADR 0020). Theme
+`revistalogos` **0.2.4**: X recibe `twitter:card=summary` para el
+logo 1:1. Plugin sin cambio (**0.2.13**).
+
+### Fixed
+- Theme `revistalogos` 0.2.4: la portada declara `twitter:card=summary`
+  para el logo 1024×1024. `summary_large_image` exige ~2:1; X no
+  pintaba la tarjeta. WhatsApp/Facebook siguen leyendo `og:image`.
+
 ## [0.3.5] — 2026-09-10
 
 Release etiquetado para FTPS de producción (ADR 0020). Incluye la

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.5**
+**Versión vigente: 0.3.6**
 
 ## Fuente de verdad
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",

--- a/tests/Features/site-preview-image.feature
+++ b/tests/Features/site-preview-image.feature
@@ -12,7 +12,7 @@ Característica: Imagen de preview del sitio
     Cuando se emiten los metadatos del documento
     Entonces og:image apunta al logo de la revista
     Y twitter:image es la misma URL
-    Y twitter:card es summary_large_image
+    Y twitter:card es summary porque el logo es 1:1
     Y el JSON-LD de Periodical incluye esa misma imagen
 
   Escenario: Una entrada con imagen destacada no sustituye la propia

--- a/tests/WordPress/SitePreviewImageTest.php
+++ b/tests/WordPress/SitePreviewImageTest.php
@@ -34,7 +34,8 @@ class SitePreviewImageTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'property="og:image"', $html );
 		$this->assertStringContainsString( $logo, $html );
 		$this->assertStringContainsString( 'name="twitter:card"', $html );
-		$this->assertStringContainsString( 'summary_large_image', $html );
+		$this->assertStringContainsString( 'content="summary"', $html );
+		$this->assertStringNotContainsString( 'summary_large_image', $html );
 		$this->assertStringContainsString( 'name="twitter:image"', $html );
 		$this->assertSame( 2, substr_count( $html, $logo ) );
 	}
@@ -74,6 +75,24 @@ class SitePreviewImageTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'name="twitter:image"', $html );
 		$this->assertStringContainsString( $featured, $html );
 		$this->assertStringNotContainsString( $this->journal_logo_url(), $html );
+	}
+
+	/**
+	 * Dado: una imagen 1:1 (el logo de la revista).
+	 * Entonces: X recibe summary, no summary_large_image.
+	 */
+	public function test_square_preview_uses_summary_card_not_large_image() {
+		$this->assertSame( 'summary', revistalogos_twitter_card_type( 1024, 1024 ) );
+		$this->assertSame( 'summary', revistalogos_twitter_card_type( 144, 144 ) );
+	}
+
+	/**
+	 * Dado: una imagen apaisada de al menos 300×157.
+	 * Entonces: X puede usar summary_large_image.
+	 */
+	public function test_landscape_preview_uses_summary_large_image_card() {
+		$this->assertSame( 'summary_large_image', revistalogos_twitter_card_type( 1200, 630 ) );
+		$this->assertSame( 'summary_large_image', revistalogos_twitter_card_type( 300, 157 ) );
 	}
 
 	/**

--- a/wordpress/wp-content/themes/revistalogos/inc/metadata-output.php
+++ b/wordpress/wp-content/themes/revistalogos/inc/metadata-output.php
@@ -64,7 +64,10 @@ function revistalogos_head_metadata() {
 			printf( '<meta property="og:image:width" content="%d">' . "\n", (int) $preview['width'] );
 			printf( '<meta property="og:image:height" content="%d">' . "\n", (int) $preview['height'] );
 		}
-		printf( '<meta name="twitter:card" content="summary_large_image">' . "\n" );
+		printf(
+			'<meta name="twitter:card" content="%s">' . "\n",
+			esc_attr( revistalogos_twitter_card_type( $preview['width'], $preview['height'] ) )
+		);
 		printf( '<meta name="twitter:image" content="%s">' . "\n", esc_url( $preview['url'] ) );
 	}
 
@@ -262,6 +265,28 @@ add_action( 'wp_head', 'revistalogos_schema_metadata', 7 );
  */
 function revistalogos_journal_logo_url() {
 	return get_theme_root_uri() . '/revistalogos/assets/img/logo-revista.png';
+}
+
+/**
+ * X card type for a preview image.
+ *
+ * summary_large_image needs ~2:1 (min 300×157). A square journal logo
+ * (1024×1024) fails that contract and X draws no image. summary is the
+ * 1:1 card.
+ *
+ * @param int $width  Image width in pixels.
+ * @param int $height Image height in pixels.
+ * @return string `summary` or `summary_large_image`
+ */
+function revistalogos_twitter_card_type( $width, $height ) {
+	$width  = (int) $width;
+	$height = (int) $height;
+
+	if ( $width >= 300 && $height >= 157 && ( $width * 2 ) >= ( $height * 3 ) ) {
+		return 'summary_large_image';
+	}
+
+	return 'summary';
 }
 
 /**

--- a/wordpress/wp-content/themes/revistalogos/style.css
+++ b/wordpress/wp-content/themes/revistalogos/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/refo44/demo-revistalogos
 Author: CENFISS
 Author URI: https://cenfiss.net
 Description: Theme clásico de la Revista de Filosofía LOGO ET SPES. Adaptación sin rediseño de la maqueta estática validada (ADR 0001/0002); todo el CSS vive en assets/css/main.css y sus módulos (ADR 0003). El dominio de contenido lo define el plugin revistalogos-core.
-Version: 0.2.3
+Version: 0.2.4
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4


### PR DESCRIPTION
## Summary
- Theme `revistalogos` **0.2.4**: `twitter:card` is `summary` when the preview is 1:1 (journal logo 1024×1024). `summary_large_image` needs ~2:1; X was drawing no image on https://logo-et-spes.cenfiss.net/
- Landscape previews (≥300×157 and ≥1.5:1) still get `summary_large_image`.
- Project version **0.3.6** so an annotated tag can match `package.json` after merge (ADR 0020). Plugin unchanged (**0.2.13**).

## Test plan
- [x] `./tools/run-phpunit-wp.sh --filter SitePreviewImageTest` (5 tests)
- [ ] After merge: `git fetch --tags origin main` then `git tag -a v0.3.6 -m "v0.3.6" origin/main` and `git push origin v0.3.6`
- [ ] Run workflow from **Tags → v0.3.6**, not `main`
- [ ] After FTPS: paste `https://logo-et-spes.cenfiss.net/` in a new X compose (cache). Expect a square summary card with the logo.


Made with [Cursor](https://cursor.com)