### PR TITLE
fix(theme): reserve editorial content as all rights reserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.7] — 2026-09-10
+
+Release etiquetado para FTPS de producción (ADR 0020). Theme
+`revistalogos` **0.2.5**: el contenido editorial pasa a todos los
+derechos reservados. Plugin sin cambio (**0.2.13**).
+
+### Changed
+- Theme `revistalogos` 0.2.5: el pie, Acerca, Ética y Privacidad
+  declaran todos los derechos reservados. Ya no ofrecen CC BY 4.0.
+  El código del sitio sigue en MIT.
+
 ## [0.3.6] — 2026-09-10
 
 Release etiquetado para FTPS de producción (ADR 0020). Theme

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,8 +1,9 @@
-Creative Commons Attribution 4.0 International
+All rights reserved
 
 Except where otherwise noted, the editorial and publication content in this
-repository is licensed under the Creative Commons Attribution 4.0
-International License.
+repository is reserved. No license is granted to copy, redistribute, or
+adapt that content without prior written permission from CENFISS or the
+rights holder.
 
 This includes, for example:
 - site copy and editorial text
@@ -13,9 +14,3 @@ This does not automatically apply to:
 - third-party materials used with separate permission or attribution
 - software code, configuration, scripts, and build tooling, which are covered
   by the `LICENSE` file unless stated otherwise
-
-License deed:
-https://creativecommons.org/licenses/by/4.0/
-
-Legal code:
-https://creativecommons.org/licenses/by/4.0/legalcode

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Detalle y motivos: `docs/adr/0019-proteger-main-trunk-based.md` §7.
 ## Licencia
 
 - **Código** (HTML, CSS, JS, PHP, scripts y configuración): **MIT**. Ver `LICENSE`.
-- **Contenido editorial y de publicación**: **Creative Commons Atribución 4.0 Internacional (CC BY 4.0)**. Ver `LICENSE-CONTENT`.
+- **Contenido editorial y de publicación**: **todos los derechos reservados**. Ver `LICENSE-CONTENT`.
 
 Los materiales de terceros conservan su propia licencia o atribución cuando corresponda.
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.6**
+**Versión vigente: 0.3.7**
 
 ## Fuente de verdad
 

--- a/docs/01-platform-plan.md
+++ b/docs/01-platform-plan.md
@@ -218,7 +218,7 @@ Incluye:
 ### Capa 8. Ancla legal e institucional
 
 - ISSN y Depósito Legal (Biblioteca Nacional de Venezuela)
-- Creative Commons Atribución 4.0 Internacional
+- Todos los derechos reservados
 - Política de privacidad y confidencialidad (autores, árbitros, visitantes)
 - Declaración de ética (alineación COPE)
 - Política de derechos de autor (ley venezolana, SAPI)

--- a/docs/09-ui-copy-sheet.md
+++ b/docs/09-ui-copy-sheet.md
@@ -47,7 +47,7 @@ Botones, menús, mensajes, formularios y estados. Criterios de voz en `07-voice-
 
 **Contacto:** CENFISS, email, web
 
-**Footer inferior:** © 2025 CENFISS. Licencia Creative Commons Atribución 4.0 Internacional.
+**Footer inferior:** © 2025 CENFISS. Todos los derechos reservados.
 
 ---
 
@@ -162,7 +162,6 @@ Botones, menús, mensajes, formularios y estados. Criterios de voz en `07-voice-
 ## 10. Enlaces externos
 
 - **CENFISS:** Se abre en nueva pestaña. Usar `rel="noopener noreferrer"`.
-- **Creative Commons:** Se abre en nueva pestaña.
 - **Guías APA / Vancouver:** Se abre en nueva pestaña.
 - **Enlaces DOI:** Se abre doi.org en nueva pestaña.
 - **Enlaces ORCID:** Se abre orcid.org en nueva pestaña.

--- a/docs/13-static-file-structure.md
+++ b/docs/13-static-file-structure.md
@@ -36,7 +36,7 @@ Dónde viven los archivos estáticos: docs, content-source, maqueta (o tema), as
 revistalogos/
 ├── docs/                  (documentación, 00–20)
 ├── LICENSE                (licencia del código del repositorio: MIT)
-├── LICENSE-CONTENT        (licencia del contenido editorial: CC BY 4.0)
+├── LICENSE-CONTENT        (contenido editorial: todos los derechos reservados)
 ├── content-source/        (contenido fuente antes de WordPress)
 │   └── PROYECTO REVISTA DE FILOSOFIA LOGO ET SPES nov 2025.md
 ├── assets/                (CSS, JS, imágenes, fuentes, PDFs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ Harness de Fase 3 (fuera de la numeración): `fase3-execution-state.md` (reanuda
 ## Licencias del repositorio
 
 - **Código del repositorio** (`HTML`, `CSS`, `JS`, scripts, configuración): licencia `MIT`. Ver `../LICENSE`.
-- **Contenido editorial y de publicación**: licencia `CC BY 4.0`. Ver `../LICENSE-CONTENT`.
+- **Contenido editorial y de publicación**: todos los derechos reservados. Ver `../LICENSE-CONTENT`.
 - **Materiales de terceros** mantienen su licencia o atribución específica cuando aplique.
 
 ---

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -256,7 +256,7 @@ Intención de propietario (2026-08-31). Criterio de aceptación visual: mockups 
 
 **Estructura (tres bloques).**
 
-Preliminares: cubierta; verso o página de respeto; portadilla (nombre canónico *Revista de Filosofía LOGO ET SPES*, Vol./N.º/año, CENFISS como editor); créditos legales (ISSN, depósito legal, copyright, CC BY 4.0, contacto); sumario tipográfico (género + título + autores + páginas *de ese PDF*; el campo `pages` del artículo sigue siendo dato de papel).
+Preliminares: cubierta; verso o página de respeto; portadilla (nombre canónico *Revista de Filosofía LOGO ET SPES*, Vol./N.º/año, CENFISS como editor); créditos legales (ISSN, depósito legal, copyright, todos los derechos reservados, contacto); sumario tipográfico (género + título + autores + páginas *de ese PDF*; el campo `pages` del artículo sigue siendo dato de papel).
 
 Cuerpo (páginas internas, no solo el índice): portadilla de género cuando exista contenido (EDITORIAL, ARTÍCULOS, ENSAYOS, RESEÑAS) — no inventar secciones vacías; editorial con maqueta propia (sin aparato de paper; aquí empieza la numeración árabe); cada artículo/ensayo/reseña en página nueva, **sin** el masthead completo de la separata (encabezado corriente mínimo); reseña abre con ficha de la obra, no con abstract de artículo; bibliografía dentro de cada pieza.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",

--- a/tests/Features/licencia-contenido-derechos-reservados.feature
+++ b/tests/Features/licencia-contenido-derechos-reservados.feature
@@ -1,0 +1,20 @@
+# language: es
+Característica: Licencia del contenido del sitio
+  Como editora de la revista
+  quiero que el sitio declare todos los derechos reservados
+  y no ofrezca Creative Commons
+  para que el contenido editorial no se pueda reutilizar sin permiso
+  # Ejecutan: tests/Unit/SiteContentLicenseTest (composer test:unit).
+
+  Escenario: El pie reserva el contenido y mantiene MIT para el código
+    Dado el pie del sitio
+    Cuando una lectora lee la licencia
+    Entonces ve todos los derechos reservados
+    Y no ve Creative Commons Atribución 4.0
+    Y el código del sitio sigue bajo MIT
+
+  Escenario: Acerca, ética y privacidad coinciden con el pie
+    Dado las fichas institucionales de licencia
+    Cuando se muestra Acerca, Ética y Privacidad
+    Entonces cada una declara todos los derechos reservados
+    Y ninguna ofrece CC BY 4.0

--- a/tests/Unit/SiteContentLicenseTest.php
+++ b/tests/Unit/SiteContentLicenseTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Public content license notice (all rights reserved).
+ *
+ * @package Revistalogos
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The live theme must reserve editorial content. CC BY 4.0 is withdrawn
+ * from public notices. Software stays MIT.
+ */
+class SiteContentLicenseTest extends TestCase {
+
+	/**
+	 * Surfaces a reader sees without opening wp-admin.
+	 *
+	 * @return array<string, string>
+	 */
+	private function public_license_files() {
+		$theme = 'wordpress/wp-content/themes/revistalogos/';
+
+		return array(
+			'footer'   => $theme . 'template-parts/footer.php',
+			'acerca'   => $theme . 'page-acerca.php',
+			'etica'    => $theme . 'page-etica.php',
+			'privacidad' => $theme . 'privacy-policy.php',
+		);
+	}
+
+	/**
+	 * Dado: el pie y las fichas institucionales.
+	 * Cuando: se lee la licencia del contenido.
+	 * Entonces: todos los derechos reservados; sin CC BY.
+	 */
+	public function test_public_theme_notices_reserve_editorial_content() {
+		foreach ( $this->public_license_files() as $surface => $relative ) {
+			$html = $this->repo_file_contents( $relative );
+
+			$this->assertStringContainsString(
+				'todos los derechos reservados',
+				mb_strtolower( $html ),
+				$surface . ' must declare all rights reserved'
+			);
+			$this->assertStringNotContainsString(
+				'creativecommons.org/licenses/by',
+				$html,
+				$surface . ' must not offer a CC BY deed'
+			);
+			$this->assertDoesNotMatchRegularExpression(
+				'/\bCC BY\b/i',
+				$html,
+				$surface . ' must not name CC BY'
+			);
+			$this->assertStringNotContainsString(
+				'Creative Commons Atribución',
+				$html,
+				$surface . ' must not name Creative Commons Attribution'
+			);
+		}
+	}
+
+	/**
+	 * Dado: el pie del sitio.
+	 * Entonces: el código sigue bajo MIT.
+	 */
+	public function test_footer_keeps_software_under_mit() {
+		$footer = $this->repo_file_contents(
+			'wordpress/wp-content/themes/revistalogos/template-parts/footer.php'
+		);
+
+		$this->assertStringContainsString( 'Código del sitio bajo', $footer );
+		$this->assertStringContainsString( 'MIT', $footer );
+		$this->assertStringContainsString(
+			'https://github.com/refo44/demo-revistalogos/blob/main/LICENSE',
+			$footer
+		);
+	}
+
+	/**
+	 * Dado: la hoja de copy del pie.
+	 * Entonces: ya no anuncia Creative Commons.
+	 */
+	public function test_copy_sheet_footer_matches_reserved_rights() {
+		$copy_sheet = $this->repo_file_contents( 'docs/09-ui-copy-sheet.md' );
+
+		$this->assertStringContainsString( 'Todos los derechos reservados', $copy_sheet );
+		$this->assertStringNotContainsString(
+			'Licencia Creative Commons Atribución 4.0 Internacional',
+			$copy_sheet
+		);
+	}
+
+	/**
+	 * @param string $relative Path from the repository root.
+	 */
+	private function repo_file_contents( $relative ) {
+		$path = dirname( __DIR__, 2 ) . '/' . $relative;
+		$this->assertFileIsReadable( $path );
+
+		$contents = file_get_contents( $path );
+		$this->assertNotFalse( $contents );
+
+		return $contents;
+	}
+}

--- a/wordpress/wp-content/themes/revistalogos/functions.php
+++ b/wordpress/wp-content/themes/revistalogos/functions.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_THEME_VERSION', '0.2.3' );
+define( 'REVISTALOGOS_THEME_VERSION', '0.2.5' );
 
 require_once get_template_directory() . '/inc/template-tags.php';
 require_once get_template_directory() . '/inc/class-nav-walker.php';

--- a/wordpress/wp-content/themes/revistalogos/page-acerca.php
+++ b/wordpress/wp-content/themes/revistalogos/page-acerca.php
@@ -40,7 +40,7 @@ while ( have_posts() ) :
 						<dd><?php esc_html_e( 'Abierto', 'revistalogos' ); ?></dd>
 
 						<dt><?php esc_html_e( 'Licencia:', 'revistalogos' ); ?></dt>
-						<dd>CC BY 4.0</dd>
+						<dd><?php esc_html_e( 'Todos los derechos reservados', 'revistalogos' ); ?></dd>
 					</dl>
 				</div>
 

--- a/wordpress/wp-content/themes/revistalogos/page-etica.php
+++ b/wordpress/wp-content/themes/revistalogos/page-etica.php
@@ -33,7 +33,7 @@ while ( have_posts() ) :
 
 				<div class="card">
 					<h2><?php esc_html_e( 'Licencias del sitio', 'revistalogos' ); ?></h2>
-					<p><?php esc_html_e( 'El contenido editorial del sitio se publica bajo', 'revistalogos' ); ?> <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY 4.0<span class="visually-hidden"> (se abre en nueva pestaña)</span></a>.</p>
+					<p><?php esc_html_e( 'El contenido editorial del sitio: todos los derechos reservados.', 'revistalogos' ); ?></p>
 					<p><?php esc_html_e( 'El código fuente del sitio se distribuye bajo licencia', 'revistalogos' ); ?> <a href="https://github.com/refo44/demo-revistalogos/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT<span class="visually-hidden"> (se abre en nueva pestaña)</span></a>.</p>
 				</div>
 				<?php

--- a/wordpress/wp-content/themes/revistalogos/privacy-policy.php
+++ b/wordpress/wp-content/themes/revistalogos/privacy-policy.php
@@ -44,7 +44,7 @@ while ( have_posts() ) :
 
 				<div class="card">
 					<h2><?php esc_html_e( 'Licencias del sitio', 'revistalogos' ); ?></h2>
-					<p><?php esc_html_e( 'El contenido editorial del sitio se publica bajo', 'revistalogos' ); ?> <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY 4.0<span class="visually-hidden"> (se abre en nueva pestaña)</span></a>.</p>
+					<p><?php esc_html_e( 'El contenido editorial del sitio: todos los derechos reservados.', 'revistalogos' ); ?></p>
 					<p><?php esc_html_e( 'El código fuente del sitio se distribuye bajo licencia', 'revistalogos' ); ?> <a href="https://github.com/refo44/demo-revistalogos/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT<span class="visually-hidden"> (se abre en nueva pestaña)</span></a>.</p>
 				</div>
 				<?php

--- a/wordpress/wp-content/themes/revistalogos/style.css
+++ b/wordpress/wp-content/themes/revistalogos/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/refo44/demo-revistalogos
 Author: CENFISS
 Author URI: https://cenfiss.net
 Description: Theme clásico de la Revista de Filosofía LOGO ET SPES. Adaptación sin rediseño de la maqueta estática validada (ADR 0001/0002); todo el CSS vive en assets/css/main.css y sus módulos (ADR 0003). El dominio de contenido lo define el plugin revistalogos-core.
-Version: 0.2.4
+Version: 0.2.5
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4

--- a/wordpress/wp-content/themes/revistalogos/template-parts/footer.php
+++ b/wordpress/wp-content/themes/revistalogos/template-parts/footer.php
@@ -85,7 +85,7 @@ $revistalogos_article_archive = get_post_type_archive_link( 'article' );
 
 		<div class="footer__bottom">
 			<p>&copy; 2025 CENFISS.</p>
-			<p><?php esc_html_e( 'Contenido del sitio bajo', 'revistalogos' ); ?> <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">Creative Commons Atribución 4.0 Internacional<span class="visually-hidden"> (se abre en nueva pestaña)</span></a>. <?php esc_html_e( 'Código del sitio bajo', 'revistalogos' ); ?> <a href="https://github.com/refo44/demo-revistalogos/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT<span class="visually-hidden"> (se abre en nueva pestaña)</span></a>.</p>
+			<p><?php esc_html_e( 'Todos los derechos reservados.', 'revistalogos' ); ?> <?php esc_html_e( 'Código del sitio bajo', 'revistalogos' ); ?> <a href="https://github.com/refo44/demo-revistalogos/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT<span class="visually-hidden"> (se abre en nueva pestaña)</span></a>.</p>
 		</div>
 
 		<div class="footer-credits">


### PR DESCRIPTION
## Summary
- El pie, Acerca, Ética y Privacidad dejan de ofrecer CC BY 4.0 y declaran **todos los derechos reservados**. El código del sitio sigue en MIT.
- Theme `revistalogos` **0.2.5**. Proyecto **0.3.7** listo para etiquetar `v0.3.7` en `main` tras el merge (ADR 0020).
- Políticas y Contacto en wp-admin de producción siguen con el texto CC BY: hay que editarlos a mano; no viajan en este PR.

## Test plan
- [x] `composer test:unit` — `SiteContentLicenseTest` (RED → GREEN)
- [ ] CI Tests verde
- [ ] Tras merge: `git fetch --tags origin main && git tag -a v0.3.7 -m "v0.3.7" origin/main && git push origin v0.3.7`
- [ ] `workflow_dispatch` de `deploy-wordpress.yml` **desde la etiqueta** `v0.3.7`
- [ ] En producción: pie sin Creative Commons; Acerca/Ética/Privacidad con derechos reservados
- [ ] En wp-admin: actualizar Políticas y Contacto si aún citan CC BY 4.0


Made with [Cursor](https://cursor.com)