### PR TITLE
chore(release): v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.9] — 2026-09-10
+
+Release etiquetado para FTPS de producción (ADR 0020). Theme
+`revistalogos` **0.2.7**. Plugin sin cambio (**0.2.14**).
+
 ### Fixed
 - Theme `revistalogos` 0.2.7: X recibe `summary_large_image` con
   tarjeta 1200×630, `twitter:title` y `twitter:description`. `og:image`

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.8**
+**Versión vigente: 0.3.9**
 
 ## Fuente de verdad
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",


### PR DESCRIPTION
## Summary
- Proyecto **0.3.9** listo para etiquetar `v0.3.9` en `main` tras el merge (ADR 0020).
- Theme `revistalogos` **0.2.7** ya está en `main` (#56): tarjeta X 1200×630 + `summary_large_image`. Plugin sin cambio (**0.2.14**).
- El gate de deploy exige que `package.json` declare la versión de la etiqueta; no se puede etiquetar `v0.3.9` sobre el merge de #56 (sigue en 0.3.8).

## Test plan
- [ ] CI Tests verde
- [ ] Tras merge:
  ```bash
  git fetch --tags origin main
  git tag -a v0.3.9 -m "v0.3.9" origin/main
  git push origin v0.3.9
  ```
- [ ] `workflow_dispatch` de `deploy-wordpress.yml` **desde** `v0.3.9`
- [ ] Pegar `https://logo-et-spes.cenfiss.net/` en un post de X y confirmar la tarjeta grande


Made with [Cursor](https://cursor.com)