### PR TITLE
chore(release): v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.10] — 2026-09-11
+
+Release etiquetado para FTPS de producción (ADR 0020). Theme
+`revistalogos` **0.2.8** y plugin `revistalogos-core` **0.2.15**.
+
+### Added
+- Plugin `revistalogos-core` 0.2.15 y theme `revistalogos` 0.2.8:
+  Ajustes → LOGO ET SPES guarda ISSN, depósito legal y prefijo DOI de
+  la edición digital ([#58](https://github.com/refo44/demo-revistalogos/issues/58)).
+  El pie y Acerca leen esos valores (vacío = «Próximamente»). `/llms.txt`
+  declara solo los que hay; no escribe «Próximamente».
+
 ## [0.3.9] — 2026-09-10
 
 Release etiquetado para FTPS de producción (ADR 0020). Theme
@@ -518,7 +530,9 @@ con la infraestructura de gobierno del proyecto en su sitio.
 - El contenido editorial de la maqueta es demostrativo y **no** se publica en producción (ver `docs/17-implementation-order` §3.1).
 - `robots.txt` permanece en `Disallow: /` mientras el sitio es prototipo.
 
-[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.3.3...HEAD
+[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.3.10...HEAD
+[0.3.10]: https://github.com/refo44/demo-revistalogos/compare/v0.3.9...v0.3.10
+[0.3.9]: https://github.com/refo44/demo-revistalogos/compare/v0.3.8...v0.3.9
 [0.3.3]: https://github.com/refo44/demo-revistalogos/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/refo44/demo-revistalogos/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/refo44/demo-revistalogos/compare/v0.3.0...v0.3.1

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.9**
+**Versión vigente: 0.3.10**
 
 ## Fuente de verdad
 

--- a/docs/03-wordpress-content-model.md
+++ b/docs/03-wordpress-content-model.md
@@ -115,13 +115,15 @@ El Vol. 12 Nº 2, los números históricos, artículos, autores, noticias, ISSN,
 | issue_number | number | Número oficial |
 | year | number | Año de publicación |
 | date_published | date | Fecha de publicación |
-| issn | text | ISSN **electrónico** (e-ISSN), cuando esté disponible. Distinto del ISSN de la versión impresa (ya obtenido por CENFISS); son dos trámites separados ante la Biblioteca Nacional — ver `22-identificadores-academicos-doi-orcid` §2.2 y ADR 0013 |
+| issn | text | ISSN de **ese número** (ficha). Distinto del ISSN de revista en Ajustes (pie / Acerca / `/llms.txt`). No autorellenar desde Ajustes. El ISSN de papel no se guarda aquí — ver `22-identificadores-academicos-doi-orcid` §2.2 y ADR 0013 |
 | doi | text | Prefijo/sufijo DOI |
 | pdf_file | file | Un PDF por número: ID de adjunto en Media Library, MIME `application/pdf`. Mismo selector nativo que el PDF de artículo. Quitar desvincula; no borra el adjunto. |
 
 **Relaciones:** Artículos vinculados al número vía post meta. El conteo de artículos es derivado (no almacenar).
 
 **Número actual:** Es el `issue` publicado con `date_published` más reciente. No almacenar un segundo indicador mientras esta regla sea suficiente.
+
+**Identificadores de la revista (Ajustes → LOGO ET SPES):** `revistalogos_journal_issn`, `revistalogos_journal_legal_deposit`, `revistalogos_journal_doi_prefix`. Solo edición digital. Pie y Acerca: vacío = «Próximamente». `/llms.txt` omite la línea vacía. No son el `issn` del número. Issue #58.
 
 ### article
 

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -175,6 +175,10 @@ Plugin `revistalogos-core` **0.2.8** y theme **0.2.1** en producción. Transfer:
 
 Ruleset `Protect main (trunk-based)` (`21337399`), activo, sin bypass. `main` exige PR; 0 approvals base (ver ADR 0019 sobre la regla de +1 approval para PRs de Copilot sin atribución); check `PHP lint, Composer audit, and unit (PHP 8.3)`; sin force-push ni borrado. Trunk-Based Development: ramas cortas, sin `develop`. GitHub **borra la rama head al mergear** (`delete_branch_on_merge`; no es el ruleset). Nombres: [Conventional Branch 1.1.0](https://conventionalbranch.org/). Mensajes: [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Ambos por convención, no en el ruleset. Preferir squash. Cursor **sigue sin** commit, push, merge ni deploy.
 
+#### 10. Identificadores digitales de la revista (ISSN, depósito legal, prefijo DOI)
+
+**Estado:** NEXT. En rama `feat/journal-identifier-settings`. Issue: [#58](https://github.com/refo44/demo-revistalogos/issues/58). Se publica en **plugin 0.2.15 / theme 0.2.8 / proyecto v0.3.10**. **No** ISSN/depósito legal de papel. Ajustes → LOGO ET SPES; pie y Acerca (vacío = «Próximamente»); `/llms.txt` omite líneas vacías. El `issn` de cada número no sustituye el ajuste.
+
 ### PLANNED
 
 No hay dependencia ADR que fuerce el orden entre diseño editorial y WU7. Se planificó **diseño antes de WU7** para que Generate/Regenerate consuman la misma plantilla (evitar dos sistemas de presentación); el ítem 3 ya está **completado y en `main`**, así que WU7 (ítem 4) es lo siguiente y debe consumir esa plantilla. El spike de la sección «Cómo Citar» (ítem 9) es **independiente** de 3 y 4: presentación del theme clásico, no PDF.

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -1,12 +1,12 @@
 ---
 phase: "Fase 3"
 status: "classic_in_production"
-current_work_unit: "Diseño editorial separata PDF (issue #10, BACKLOG 3) implementado en rama"
-current_branch: "feat/article-pdf-editorial-design"
+current_work_unit: "Identificadores digitales de revista (issue #58, BACKLOG 10) en rama"
+current_branch: "feat/journal-identifier-settings"
 last_verified_commit: "8ebc8ee"
 last_checkpoint_commit: "8ebc8ee"
-updated_at: "2026-08-28"
-next_action: "PR de feat/article-pdf-editorial-design (issue #10). Next FTPS needs a new vX.Y.Z tag (ADR 0020). Default OFF. No backfill. ADR 0017 WU7 not started."
+updated_at: "2026-09-11"
+next_action: "PR de feat/journal-identifier-settings (issue #58). Tras merge: etiqueta anotada v0.3.10 y workflow_dispatch desde esa etiqueta (ADR 0020). Default OFF. No backfill. ADR 0017 WU7 not started."
 blocked: false
 ---
 
@@ -652,12 +652,14 @@ Recuperación institucional **ya hecha** (Pages reales permanentes). Carga
 editorial real en proceso desde wp-admin (**no** completa). Docker local:
 `http://localhost:8080` (WordPress 7.1, PHP **8.3**).
 
-Siguiente acción priorizada — **no** reabrir el checkpoint 0.2.8
+Siguiente acción priorizada — **issue #58** en
+`feat/journal-identifier-settings`. Tras merge a `main`: etiqueta
+anotada `v0.3.10` (plugin 0.2.15 / theme 0.2.8) y
+`workflow_dispatch` desde esa etiqueta (ADR 0020). **No** reabrir el
+checkpoint 0.2.8
 ([issue #9](https://github.com/refo44/demo-revistalogos/issues/9)
-cerrado). Plugin **0.2.8** está en Git y en producción. El próximo FTPS
-exige un **nuevo** `vX.Y.Z` (ADR 0020); no despachar desde `v0.2.0`.
-Default OFF; sin backfill; WU7 no iniciado. No pushear a `main`; ramas
-cortas + PR (ADR 0019).
+cerrado). No despachar desde `v0.2.0`. Default OFF; sin backfill; WU7
+no iniciado. No pushear a `main`; ramas cortas + PR (ADR 0019).
 Trabajo pendiente aceptado (no duplicar aquí):
 `docs/adr/BACKLOG.md` § Trabajo pendiente aceptado.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",

--- a/tests/Features/identificadores-revista.feature
+++ b/tests/Features/identificadores-revista.feature
@@ -1,0 +1,28 @@
+# language: es
+Característica: Identificadores digitales de la revista
+  Como administrador de LOGO ET SPES
+  quiero guardar ISSN, depósito legal y prefijo DOI en Ajustes
+  para que el pie, Acerca y /llms.txt muestren los valores oficiales
+  # Issue #58. Ejecutan: tests/Unit/JournalIdentifierSettingsTest,
+  # tests/Unit/JournalIdentifierSurfacesTest, tests/Unit/LlmsTxtDocumentTest
+  # (composer test:unit) y tests/WordPress/JournalIdentifierSettingsTest
+  # (composer test:wp).
+
+  Escenario: Los campos vacíos no inventan un identificador
+    Dado que ISSN, depósito legal y prefijo DOI no están guardados
+    Cuando un visitante ve el pie o Acerca
+    Entonces cada etiqueta muestra Próximamente
+    Y /llms.txt omite esas líneas
+
+  Escenario: Un administrador guarda los identificadores digitales
+    Dado Ajustes → LOGO ET SPES
+    Cuando guarda un ISSN, un depósito legal y un prefijo DOI
+    Entonces el pie muestra ese ISSN y ese depósito legal
+    Y Acerca muestra esos tres valores
+    Y /llms.txt declara solo los valores guardados
+    Y las etiquetas públicas no dicen electrónico ni digital
+
+  Escenario: El ISSN de un número no sustituye el de la revista
+    Dado un número con su propio campo issn
+    Cuando se genera el pie o /llms.txt
+    Entonces se lee el ajuste de revista, no el meta del número

--- a/tests/Support/bootstrap.php
+++ b/tests/Support/bootstrap.php
@@ -31,4 +31,5 @@ require_once $article_pdf_dir . '/class-article-pdf-generation-orchestrator.php'
 require_once $article_pdf_dir . '/class-dompdf-article-pdf-renderer.php';
 require_once $plugin_root . '/includes/integrations/class-native-sitemap.php';
 require_once $plugin_root . '/includes/integrations/class-llms-txt.php';
+require_once $plugin_root . '/includes/metadata/class-journal-identifier-settings.php';
 require_once $plugin_root . '/includes/migration/class-withdrawn-cc-by-notices.php';

--- a/tests/Unit/JournalIdentifierSettingsTest.php
+++ b/tests/Unit/JournalIdentifierSettingsTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Journal-level digital identifiers (issue #58).
+ *
+ * @package Revistalogos
+ */
+
+use PHPUnit\Framework\TestCase;
+use Revistalogos_Core\Journal_Identifier_Settings;
+
+require_once dirname( __DIR__, 2 ) . '/wordpress/wp-content/plugins/revistalogos-core/includes/metadata/class-journal-identifier-settings.php';
+
+/**
+ * Stored values stay inert text. Empty is empty — never a invented ISSN.
+ *
+ * @ticket 58
+ */
+class JournalIdentifierSettingsTest extends TestCase {
+
+	/**
+	 * Dado: un valor con espacios o markup.
+	 * Entonces: queda texto plano recortado.
+	 */
+	public function test_sanitize_keeps_plain_trimmed_text() {
+		$this->assertSame( '2443-5678', Journal_Identifier_Settings::sanitize( '  2443-5678  ' ) );
+		$this->assertSame( '2443-5678', Journal_Identifier_Settings::sanitize( '<b>2443-5678</b>' ) );
+		$this->assertSame( '10.12345', Journal_Identifier_Settings::sanitize( '10.12345' ) );
+	}
+
+	/**
+	 * Dado: un valor vacío o no textual.
+	 * Entonces: se guarda cadena vacía.
+	 */
+	public function test_sanitize_rejects_empty_and_non_scalar_values() {
+		$this->assertSame( '', Journal_Identifier_Settings::sanitize( '' ) );
+		$this->assertSame( '', Journal_Identifier_Settings::sanitize( '   ' ) );
+		$this->assertSame( '', Journal_Identifier_Settings::sanitize( array( '2443-5678' ) ) );
+		$this->assertSame( '', Journal_Identifier_Settings::sanitize( null ) );
+	}
+}

--- a/tests/Unit/JournalIdentifierSurfacesTest.php
+++ b/tests/Unit/JournalIdentifierSurfacesTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Public surfaces read journal identifiers from plugin settings (issue #58).
+ *
+ * @package Revistalogos
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Footer and Acerca keep the public labels and do not hardcode the values.
+ *
+ * @ticket 58
+ */
+class JournalIdentifierSurfacesTest extends TestCase {
+
+	/**
+	 * Dado: el pie del sitio.
+	 * Entonces: ISSN y depósito legal salen del ajuste, con las etiquetas actuales.
+	 */
+	public function test_footer_reads_issn_and_legal_deposit_from_settings() {
+		$footer = $this->repo_file_contents(
+			'wordpress/wp-content/themes/revistalogos/template-parts/footer.php'
+		);
+
+		$this->assertStringContainsString( '<strong>ISSN:</strong>', $footer );
+		$this->assertStringContainsString( 'Depósito Legal:', $footer );
+		$this->assertStringContainsString( "revistalogos_journal_identifier_text( 'issn' )", $footer );
+		$this->assertStringContainsString( "revistalogos_journal_identifier_text( 'legal_deposit' )", $footer );
+		$this->assertStringNotContainsString( 'electrónico', $footer );
+		$this->assertStringNotContainsString( 'digital', mb_strtolower( $footer ) );
+	}
+
+	/**
+	 * Dado: la ficha de Acerca.
+	 * Entonces: ISSN, depósito legal y DOI salen del ajuste.
+	 */
+	public function test_acerca_reads_journal_identifiers_from_settings() {
+		$acerca = $this->repo_file_contents(
+			'wordpress/wp-content/themes/revistalogos/page-acerca.php'
+		);
+
+		$this->assertStringContainsString( '<dt>ISSN:</dt>', $acerca );
+		$this->assertStringContainsString( 'Depósito Legal:', $acerca );
+		$this->assertStringContainsString( '<dt>DOI:</dt>', $acerca );
+		$this->assertStringContainsString( "revistalogos_journal_identifier_text( 'issn' )", $acerca );
+		$this->assertStringContainsString( "revistalogos_journal_identifier_text( 'legal_deposit' )", $acerca );
+		$this->assertStringContainsString( "revistalogos_journal_identifier_text( 'doi_prefix' )", $acerca );
+	}
+
+	/**
+	 * @param string $relative Path from the repository root.
+	 */
+	private function repo_file_contents( $relative ) {
+		$path = dirname( __DIR__, 2 ) . '/' . $relative;
+		$this->assertFileIsReadable( $path );
+
+		$contents = file_get_contents( $path );
+		$this->assertNotFalse( $contents );
+
+		return $contents;
+	}
+}

--- a/tests/Unit/LlmsTxtDocumentTest.php
+++ b/tests/Unit/LlmsTxtDocumentTest.php
@@ -32,6 +32,31 @@ class LlmsTxtDocumentTest extends TestCase {
 		$this->assertStringNotContainsString( 'CC BY', $document );
 		$this->assertStringNotContainsString( 'Número actual', $document );
 		$this->assertStringNotContainsString( 'Información institucional', $document );
+		$this->assertStringNotContainsString( 'ISSN:', $document );
+		$this->assertStringNotContainsString( 'Depósito Legal:', $document );
+		$this->assertStringNotContainsString( 'DOI:', $document );
+		$this->assertStringNotContainsString( 'Próximamente', $document );
+	}
+
+	/**
+	 * Dado: identificadores digitales guardados.
+	 * Entonces: /llms.txt los declara; no escribe Próximamente.
+	 *
+	 * @ticket 58
+	 */
+	public function test_document_lists_stored_journal_identifiers() {
+		$catalog                   = $this->empty_catalog();
+		$catalog['issn']           = '2443-5678';
+		$catalog['legal_deposit']  = 'DC2026000123';
+		$catalog['doi_prefix']     = '10.12345';
+
+		$document = Llms_Txt::format_document( $catalog );
+
+		$this->assertStringContainsString( 'ISSN: 2443-5678', $document );
+		$this->assertStringContainsString( 'Depósito Legal: DC2026000123', $document );
+		$this->assertStringContainsString( 'DOI: 10.12345', $document );
+		$this->assertStringNotContainsString( 'Próximamente', $document );
+		$this->assertStringNotContainsString( 'electrónico', $document );
 	}
 
 	/**

--- a/tests/WordPress/JournalIdentifierSettingsTest.php
+++ b/tests/WordPress/JournalIdentifierSettingsTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Journal identifier options on Settings → LOGO ET SPES (issue #58).
+ *
+ * @package Revistalogos
+ */
+
+use Revistalogos_Core\Article_Pdf_Publication_Settings;
+use Revistalogos_Core\Journal_Identifier_Settings;
+use Revistalogos_Core\Llms_Txt;
+
+/**
+ * Site-level digital identifiers. Missing option is empty, never invented.
+ *
+ * @ticket 58
+ */
+class JournalIdentifierSettingsTest extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		delete_option( Journal_Identifier_Settings::OPTION_ISSN );
+		delete_option( Journal_Identifier_Settings::OPTION_LEGAL_DEPOSIT );
+		delete_option( Journal_Identifier_Settings::OPTION_DOI_PREFIX );
+	}
+
+	/**
+	 * Dado: las opciones no existen.
+	 * Entonces: los getters quedan vacíos.
+	 */
+	public function test_missing_options_are_empty() {
+		$this->assertSame( '', Journal_Identifier_Settings::issn() );
+		$this->assertSame( '', Journal_Identifier_Settings::legal_deposit() );
+		$this->assertSame( '', Journal_Identifier_Settings::doi_prefix() );
+	}
+
+	/**
+	 * Dado: valores oficiales guardados.
+	 * Entonces: el plugin los devuelve tal cual.
+	 */
+	public function test_stored_options_are_returned() {
+		update_option( Journal_Identifier_Settings::OPTION_ISSN, '2443-5678' );
+		update_option( Journal_Identifier_Settings::OPTION_LEGAL_DEPOSIT, 'DC2026000123' );
+		update_option( Journal_Identifier_Settings::OPTION_DOI_PREFIX, '10.12345' );
+
+		$this->assertSame( '2443-5678', Journal_Identifier_Settings::issn() );
+		$this->assertSame( 'DC2026000123', Journal_Identifier_Settings::legal_deposit() );
+		$this->assertSame( '10.12345', Journal_Identifier_Settings::doi_prefix() );
+	}
+
+	/**
+	 * Dado: Ajustes → LOGO ET SPES.
+	 * Entonces: la pantalla ofrece ISSN, depósito legal y prefijo DOI.
+	 */
+	public function test_logo_et_spes_settings_page_offers_identifier_fields() {
+		Article_Pdf_Publication_Settings::register_setting();
+		Journal_Identifier_Settings::register_setting();
+
+		ob_start();
+		Article_Pdf_Publication_Settings::render_page();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="' . Journal_Identifier_Settings::OPTION_ISSN . '"', $html );
+		$this->assertStringContainsString( 'name="' . Journal_Identifier_Settings::OPTION_LEGAL_DEPOSIT . '"', $html );
+		$this->assertStringContainsString( 'name="' . Journal_Identifier_Settings::OPTION_DOI_PREFIX . '"', $html );
+		$this->assertStringContainsString( 'ISSN', $html );
+		$this->assertStringContainsString( 'Depósito Legal', $html );
+		$this->assertStringContainsString( 'Prefijo DOI', $html );
+	}
+
+	/**
+	 * Dado: identificadores guardados.
+	 * Entonces: /llms.txt los incluye; vacío no escribe Próximamente.
+	 */
+	public function test_llms_txt_includes_stored_identifiers_and_omits_empty_ones() {
+		$empty = Llms_Txt::render();
+		$this->assertStringNotContainsString( 'ISSN:', $empty );
+		$this->assertStringNotContainsString( 'Depósito Legal:', $empty );
+		$this->assertStringNotContainsString( 'DOI:', $empty );
+		$this->assertStringNotContainsString( 'Próximamente', $empty );
+
+		update_option( Journal_Identifier_Settings::OPTION_ISSN, '2443-5678' );
+		update_option( Journal_Identifier_Settings::OPTION_LEGAL_DEPOSIT, 'DC2026000123' );
+		update_option( Journal_Identifier_Settings::OPTION_DOI_PREFIX, '10.12345' );
+
+		$document = Llms_Txt::render();
+		$this->assertStringContainsString( 'ISSN: 2443-5678', $document );
+		$this->assertStringContainsString( 'Depósito Legal: DC2026000123', $document );
+		$this->assertStringContainsString( 'DOI: 10.12345', $document );
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
@@ -48,6 +48,7 @@ class Plugin {
 		Relationships::register_hooks();
 		Contact_Form_Integration::register_hooks();
 		Article_Pdf_Publication_Settings::register_hooks();
+		Journal_Identifier_Settings::register_hooks();
 		Article_Pdf_Publication_Enforcer::register_hooks();
 		Native_Sitemap::register_hooks();
 		Llms_Txt::register_hooks();
@@ -81,6 +82,7 @@ class Plugin {
 		require_once $includes . 'taxonomies/class-taxonomies.php';
 		require_once $includes . 'metadata/class-metadata.php';
 		require_once $includes . 'metadata/class-meta-boxes.php';
+		require_once $includes . 'metadata/class-journal-identifier-settings.php';
 		require_once $includes . 'relationships/class-relationships.php';
 		require_once $includes . 'roles/class-roles.php';
 		require_once $includes . 'queries/class-queries.php';

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/integrations/class-llms-txt.php
@@ -355,6 +355,15 @@ class Llms_Txt {
 		$lines[] = '> ' . $catalog['description'];
 		$lines[] = '';
 		$lines[] = 'Sitio: ' . $catalog['home_url'];
+		if ( ! empty( $catalog['issn'] ) ) {
+			$lines[] = 'ISSN: ' . $catalog['issn'];
+		}
+		if ( ! empty( $catalog['legal_deposit'] ) ) {
+			$lines[] = 'Depósito Legal: ' . $catalog['legal_deposit'];
+		}
+		if ( ! empty( $catalog['doi_prefix'] ) ) {
+			$lines[] = 'DOI: ' . $catalog['doi_prefix'];
+		}
 		$lines[] = 'Licencia del contenido: todos los derechos reservados.';
 		$lines[] = 'Código del sitio: MIT.';
 		$lines[] = '';
@@ -447,6 +456,9 @@ class Llms_Txt {
 			'name'                 => self::JOURNAL_NAME,
 			'description'          => self::JOURNAL_DESCRIPTION,
 			'home_url'             => home_url( '/' ),
+			'issn'                 => Journal_Identifier_Settings::issn(),
+			'legal_deposit'        => Journal_Identifier_Settings::legal_deposit(),
+			'doi_prefix'           => Journal_Identifier_Settings::doi_prefix(),
 			'issues_url'           => get_post_type_archive_link( Content_Types::ISSUE ) ?: home_url( '/revista/numeros/' ),
 			'articles_url'         => get_post_type_archive_link( Content_Types::ARTICLE ) ?: home_url( '/revista/articulos/' ),
 			'authors_url'          => get_post_type_archive_link( Content_Types::AUTHOR ) ?: home_url( '/revista/autores/' ),

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/metadata/class-journal-identifier-settings.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/metadata/class-journal-identifier-settings.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Site-level digital journal identifiers (issue #58).
+ *
+ * Print-edition ISSN and depósito legal are out of scope. Empty option
+ * means empty — the theme shows «Próximamente»; /llms.txt omits the line.
+ *
+ * @package Revistalogos_Core
+ */
+
+namespace Revistalogos_Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Settings API fields on Ajustes → LOGO ET SPES.
+ */
+class Journal_Identifier_Settings {
+
+	const OPTION_ISSN          = 'revistalogos_journal_issn';
+	const OPTION_LEGAL_DEPOSIT = 'revistalogos_journal_legal_deposit';
+	const OPTION_DOI_PREFIX    = 'revistalogos_journal_doi_prefix';
+
+	/**
+	 * Register Settings API hooks. Does not write options.
+	 */
+	public static function register_hooks() {
+		add_action( 'admin_init', array( __CLASS__, 'register_setting' ) );
+	}
+
+	/**
+	 * ISSN of the digital edition.
+	 *
+	 * @return string
+	 */
+	public static function issn() {
+		return self::stored( self::OPTION_ISSN );
+	}
+
+	/**
+	 * Digital legal-deposit number.
+	 *
+	 * @return string
+	 */
+	public static function legal_deposit() {
+		return self::stored( self::OPTION_LEGAL_DEPOSIT );
+	}
+
+	/**
+	 * Crossref DOI prefix, inert until Fase 4.
+	 *
+	 * @return string
+	 */
+	public static function doi_prefix() {
+		return self::stored( self::OPTION_DOI_PREFIX );
+	}
+
+	/**
+	 * @param string $key issn | legal_deposit | doi_prefix.
+	 * @return string
+	 */
+	public static function value( $key ) {
+		if ( 'issn' === $key ) {
+			return self::issn();
+		}
+
+		if ( 'legal_deposit' === $key ) {
+			return self::legal_deposit();
+		}
+
+		if ( 'doi_prefix' === $key ) {
+			return self::doi_prefix();
+		}
+
+		return '';
+	}
+
+	/**
+	 * Store plain trimmed text. No ISSN/DOI checksum (Fase 4).
+	 *
+	 * @param mixed $value Raw submitted value.
+	 * @return string
+	 */
+	public static function sanitize( $value ) {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		$text = trim( (string) $value );
+
+		if ( function_exists( 'sanitize_text_field' ) ) {
+			return sanitize_text_field( $text );
+		}
+
+		return trim( strip_tags( $text ) );
+	}
+
+	/**
+	 * Fields on the existing LOGO ET SPES settings page.
+	 */
+	public static function register_setting() {
+		foreach ( self::fields() as $option => $field ) {
+			register_setting(
+				Article_Pdf_Publication_Settings::GROUP,
+				$option,
+				array(
+					'type'              => 'string',
+					'sanitize_callback' => array( __CLASS__, 'sanitize' ),
+					'default'           => '',
+					'show_in_rest'      => false,
+				)
+			);
+		}
+
+		add_settings_section(
+			'revistalogos_journal_identifiers',
+			__( 'Identificadores de la revista', 'revistalogos-core' ),
+			array( __CLASS__, 'render_section' ),
+			Article_Pdf_Publication_Settings::PAGE_SLUG
+		);
+
+		foreach ( self::fields() as $option => $field ) {
+			add_settings_field(
+				$option,
+				$field['label'],
+				array( __CLASS__, 'render_field' ),
+				Article_Pdf_Publication_Settings::PAGE_SLUG,
+				'revistalogos_journal_identifiers',
+				array(
+					'option'      => $option,
+					'description' => $field['description'],
+				)
+			);
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	public static function render_section() {
+		echo '<p>' . esc_html__( 'Solo la edición digital. Un campo vacío se muestra como «Próximamente» en el sitio y no aparece en /llms.txt.', 'revistalogos-core' ) . '</p>';
+	}
+
+	/**
+	 * @param array<string, string> $args Field args from add_settings_field.
+	 * @return void
+	 */
+	public static function render_field( $args ) {
+		$option = isset( $args['option'] ) ? (string) $args['option'] : '';
+		if ( '' === $option ) {
+			return;
+		}
+
+		printf(
+			'<input type="text" class="regular-text" name="%1$s" value="%2$s">',
+			esc_attr( $option ),
+			esc_attr( self::stored( $option ) )
+		);
+
+		if ( ! empty( $args['description'] ) ) {
+			echo '<p class="description">' . esc_html( $args['description'] ) . '</p>';
+		}
+	}
+
+	/**
+	 * @param string $option Option name.
+	 * @return string
+	 */
+	private static function stored( $option ) {
+		if ( ! function_exists( 'get_option' ) ) {
+			return '';
+		}
+
+		$value = get_option( $option, '' );
+
+		return is_string( $value ) ? $value : '';
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string}>
+	 */
+	private static function fields() {
+		return array(
+			self::OPTION_ISSN          => array(
+				'label'       => __( 'ISSN', 'revistalogos-core' ),
+				'description' => __( 'Pie, Acerca y /llms.txt.', 'revistalogos-core' ),
+			),
+			self::OPTION_LEGAL_DEPOSIT => array(
+				'label'       => __( 'Depósito Legal', 'revistalogos-core' ),
+				'description' => __( 'Pie, Acerca y /llms.txt.', 'revistalogos-core' ),
+			),
+			self::OPTION_DOI_PREFIX    => array(
+				'label'       => __( 'Prefijo DOI', 'revistalogos-core' ),
+				'description' => __( 'Acerca y /llms.txt. Inerte hasta Crossref.', 'revistalogos-core' ),
+			),
+		);
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -3,7 +3,7 @@ Contributors: cenfiss
 Requires at least: 6.4
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 0.2.14
+Stable tag: 0.2.15
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,11 @@ Fase 3: los campos `issn`, `doi` y `orcid` son almacenamiento base inerte;
 la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 == Changelog ==
+
+= 0.2.15 =
+* Settings → LOGO ET SPES stores digital ISSN, depósito legal and DOI
+  prefix (issue #58). Footer, Acerca and `/llms.txt` read those options.
+  Empty stays «Próximamente» on the site and is omitted from `/llms.txt`.
 
 = 0.2.14 =
 * Withdraw CC BY 4.0 from Políticas and Contacto page bodies. The

--- a/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Revista LOGO ET SPES — Core
  * Plugin URI:        https://github.com/refo44/demo-revistalogos
  * Description:       Modelo de contenido de la Revista de Filosofía LOGO ET SPES: números, artículos, autores, taxonomías, rol Managing Editor, migración de contenido institucional y fixtures. El theme revistalogos solo presenta; este plugin es el dueño del dominio (ADR 0005).
- * Version:           0.2.14
+ * Version:           0.2.15
  * Requires at least: 6.4
  * Tested up to:      7.1
  * Requires PHP:      7.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_CORE_VERSION', '0.2.14' );
+define( 'REVISTALOGOS_CORE_VERSION', '0.2.15' );
 define( 'REVISTALOGOS_CORE_FILE', __FILE__ );
 define( 'REVISTALOGOS_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'REVISTALOGOS_CORE_URL', plugin_dir_url( __FILE__ ) );

--- a/wordpress/wp-content/themes/revistalogos/functions.php
+++ b/wordpress/wp-content/themes/revistalogos/functions.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_THEME_VERSION', '0.2.7' );
+define( 'REVISTALOGOS_THEME_VERSION', '0.2.8' );
 
 require_once get_template_directory() . '/inc/template-tags.php';
 require_once get_template_directory() . '/inc/class-nav-walker.php';

--- a/wordpress/wp-content/themes/revistalogos/inc/template-tags.php
+++ b/wordpress/wp-content/themes/revistalogos/inc/template-tags.php
@@ -12,6 +12,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Public text for a journal-level digital identifier.
+ * Empty stored value (or missing plugin) is «Próximamente».
+ *
+ * @param string $key issn | legal_deposit | doi_prefix.
+ * @return string
+ */
+function revistalogos_journal_identifier_text( $key ) {
+	$stored = '';
+
+	if ( class_exists( '\Revistalogos_Core\Journal_Identifier_Settings' ) ) {
+		$stored = \Revistalogos_Core\Journal_Identifier_Settings::value( $key );
+	}
+
+	if ( '' !== $stored ) {
+		return $stored;
+	}
+
+	return __( 'Próximamente', 'revistalogos' );
+}
+
+/**
  * Current issue (derived by the plugin; null without it).
  *
  * @return WP_Post|null

--- a/wordpress/wp-content/themes/revistalogos/page-acerca.php
+++ b/wordpress/wp-content/themes/revistalogos/page-acerca.php
@@ -25,10 +25,13 @@ while ( have_posts() ) :
 					<h3><?php esc_html_e( 'Información de la Revista', 'revistalogos' ); ?></h3>
 					<dl>
 						<dt>ISSN:</dt>
-						<dd><?php esc_html_e( 'Próximamente', 'revistalogos' ); ?></dd>
+						<dd><?php echo esc_html( revistalogos_journal_identifier_text( 'issn' ) ); ?></dd>
+
+						<dt><?php esc_html_e( 'Depósito Legal:', 'revistalogos' ); ?></dt>
+						<dd><?php echo esc_html( revistalogos_journal_identifier_text( 'legal_deposit' ) ); ?></dd>
 
 						<dt>DOI:</dt>
-						<dd><?php esc_html_e( 'Próximamente', 'revistalogos' ); ?></dd>
+						<dd><?php echo esc_html( revistalogos_journal_identifier_text( 'doi_prefix' ) ); ?></dd>
 
 						<dt><?php esc_html_e( 'Frecuencia:', 'revistalogos' ); ?></dt>
 						<dd><?php esc_html_e( 'Anual', 'revistalogos' ); ?></dd>

--- a/wordpress/wp-content/themes/revistalogos/style.css
+++ b/wordpress/wp-content/themes/revistalogos/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/refo44/demo-revistalogos
 Author: CENFISS
 Author URI: https://cenfiss.net
 Description: Theme clásico de la Revista de Filosofía LOGO ET SPES. Adaptación sin rediseño de la maqueta estática validada (ADR 0001/0002); todo el CSS vive en assets/css/main.css y sus módulos (ADR 0003). El dominio de contenido lo define el plugin revistalogos-core.
-Version: 0.2.7
+Version: 0.2.8
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4

--- a/wordpress/wp-content/themes/revistalogos/template-parts/footer.php
+++ b/wordpress/wp-content/themes/revistalogos/template-parts/footer.php
@@ -20,8 +20,8 @@ $revistalogos_article_archive = get_post_type_archive_link( 'article' );
 			<div class="footer__section">
 				<h3>LOGO ET SPES</h3>
 				<p><?php esc_html_e( 'Revista de Filosofía adscrita, auspiciada y editada por el Centro de Filosofía para la Investigación <Stanislao Strba> - CENFISS.', 'revistalogos' ); ?></p>
-				<p><strong>ISSN:</strong> <?php esc_html_e( 'Próximamente', 'revistalogos' ); ?><br>
-				<strong><?php esc_html_e( 'Depósito Legal:', 'revistalogos' ); ?></strong> <?php esc_html_e( 'Próximamente', 'revistalogos' ); ?></p>
+				<p><strong>ISSN:</strong> <?php echo esc_html( revistalogos_journal_identifier_text( 'issn' ) ); ?><br>
+				<strong><?php esc_html_e( 'Depósito Legal:', 'revistalogos' ); ?></strong> <?php echo esc_html( revistalogos_journal_identifier_text( 'legal_deposit' ) ); ?></p>
 			</div>
 
 			<div class="footer__section">


### PR DESCRIPTION
## Summary
- Ajustes → LOGO ET SPES guarda ISSN, depósito legal y prefijo DOI de la edición digital ([#58](https://github.com/refo44/demo-revistalogos/issues/58)).
- El pie y Acerca leen esos valores (vacío = «Próximamente»). `/llms.txt` declara solo los que hay.
- Versiones listas para etiquetar tras el merge: proyecto **v0.3.10**, plugin **0.2.15**, theme **0.2.8**.

## Test plan
- [x] `./tools/php-lint.sh` (97 files OK)
- [x] `markdownlint-cli2` (65 files, 0 errors)
- [x] `./tools/run-phpunit.sh` (45 unit)
- [x] `./tools/run-phpunit-wp.sh --filter 'JournalIdentifier|LlmsTxtCatalog'` (17 WP)
- [ ] CI Tests green
- [ ] Tras merge: `git tag -a v0.3.10 -m "v0.3.10" origin/main` y push de la etiqueta (ADR 0020)


Made with [Cursor](https://cursor.com)