### PR TITLE
chore(release): v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.11] — 2026-09-11
+
+Release etiquetado para FTPS de producción (ADR 0020). Plugin
+`revistalogos-core` **0.2.16**. Theme sin cambio (**0.2.8**).
+
+### Changed
+- Plugin `revistalogos-core` 0.2.16: ISSN, depósito legal y prefijo DOI
+  en Ajustes ya no muestran el pie «Pie, Acerca y /llms.txt» ni
+  «Inerte hasta Crossref».
+
 ## [0.3.10] — 2026-09-11
 
 Release etiquetado para FTPS de producción (ADR 0020). Theme
@@ -530,7 +540,8 @@ con la infraestructura de gobierno del proyecto en su sitio.
 - El contenido editorial de la maqueta es demostrativo y **no** se publica en producción (ver `docs/17-implementation-order` §3.1).
 - `robots.txt` permanece en `Disallow: /` mientras el sitio es prototipo.
 
-[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.3.10...HEAD
+[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.3.11...HEAD
+[0.3.11]: https://github.com/refo44/demo-revistalogos/compare/v0.3.10...v0.3.11
 [0.3.10]: https://github.com/refo44/demo-revistalogos/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/refo44/demo-revistalogos/compare/v0.3.8...v0.3.9
 [0.3.3]: https://github.com/refo44/demo-revistalogos/compare/v0.3.2...v0.3.3

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.10**
+**Versión vigente: 0.3.11**
 
 ## Fuente de verdad
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "revistalogos",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "revistalogos",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",

--- a/tests/Unit/JournalIdentifierSettingsTest.php
+++ b/tests/Unit/JournalIdentifierSettingsTest.php
@@ -37,4 +37,30 @@ class JournalIdentifierSettingsTest extends TestCase {
 		$this->assertSame( '', Journal_Identifier_Settings::sanitize( array( '2443-5678' ) ) );
 		$this->assertSame( '', Journal_Identifier_Settings::sanitize( null ) );
 	}
+
+	/**
+	 * Dado: Ajustes → LOGO ET SPES.
+	 * Entonces: los campos no llevan pie de ayuda por superficie.
+	 */
+	public function test_settings_fields_have_no_surface_captions() {
+		$settings = $this->repo_file_contents(
+			'wordpress/wp-content/plugins/revistalogos-core/includes/metadata/class-journal-identifier-settings.php'
+		);
+
+		$this->assertStringNotContainsString( 'Pie, Acerca y /llms.txt.', $settings );
+		$this->assertStringNotContainsString( 'Inerte hasta Crossref.', $settings );
+	}
+
+	/**
+	 * @param string $relative Path from the repository root.
+	 */
+	private function repo_file_contents( $relative ) {
+		$path = dirname( __DIR__, 2 ) . '/' . $relative;
+		$this->assertFileIsReadable( $path );
+
+		$contents = file_get_contents( $path );
+		$this->assertNotFalse( $contents );
+
+		return $contents;
+	}
 }

--- a/tests/WordPress/JournalIdentifierSettingsTest.php
+++ b/tests/WordPress/JournalIdentifierSettingsTest.php
@@ -66,6 +66,8 @@ class JournalIdentifierSettingsTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'ISSN', $html );
 		$this->assertStringContainsString( 'Depósito Legal', $html );
 		$this->assertStringContainsString( 'Prefijo DOI', $html );
+		$this->assertStringNotContainsString( 'Pie, Acerca y /llms.txt.', $html );
+		$this->assertStringNotContainsString( 'Inerte hasta Crossref.', $html );
 	}
 
 	/**

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/metadata/class-journal-identifier-settings.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/metadata/class-journal-identifier-settings.php
@@ -129,8 +129,7 @@ class Journal_Identifier_Settings {
 				Article_Pdf_Publication_Settings::PAGE_SLUG,
 				'revistalogos_journal_identifiers',
 				array(
-					'option'      => $option,
-					'description' => $field['description'],
+					'option' => $option,
 				)
 			);
 		}
@@ -158,10 +157,6 @@ class Journal_Identifier_Settings {
 			esc_attr( $option ),
 			esc_attr( self::stored( $option ) )
 		);
-
-		if ( ! empty( $args['description'] ) ) {
-			echo '<p class="description">' . esc_html( $args['description'] ) . '</p>';
-		}
 	}
 
 	/**
@@ -179,21 +174,18 @@ class Journal_Identifier_Settings {
 	}
 
 	/**
-	 * @return array<string, array{label: string, description: string}>
+	 * @return array<string, array{label: string}>
 	 */
 	private static function fields() {
 		return array(
 			self::OPTION_ISSN          => array(
-				'label'       => __( 'ISSN', 'revistalogos-core' ),
-				'description' => __( 'Pie, Acerca y /llms.txt.', 'revistalogos-core' ),
+				'label' => __( 'ISSN', 'revistalogos-core' ),
 			),
 			self::OPTION_LEGAL_DEPOSIT => array(
-				'label'       => __( 'Depósito Legal', 'revistalogos-core' ),
-				'description' => __( 'Pie, Acerca y /llms.txt.', 'revistalogos-core' ),
+				'label' => __( 'Depósito Legal', 'revistalogos-core' ),
 			),
 			self::OPTION_DOI_PREFIX    => array(
-				'label'       => __( 'Prefijo DOI', 'revistalogos-core' ),
-				'description' => __( 'Acerca y /llms.txt. Inerte hasta Crossref.', 'revistalogos-core' ),
+				'label' => __( 'Prefijo DOI', 'revistalogos-core' ),
 			),
 		);
 	}

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -3,7 +3,7 @@ Contributors: cenfiss
 Requires at least: 6.4
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 0.2.15
+Stable tag: 0.2.16
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,9 @@ Fase 3: los campos `issn`, `doi` y `orcid` son almacenamiento base inerte;
 la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 == Changelog ==
+
+= 0.2.16 =
+* Settings → LOGO ET SPES identifier fields have no per-field captions.
 
 = 0.2.15 =
 * Settings → LOGO ET SPES stores digital ISSN, depósito legal and DOI

--- a/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Revista LOGO ET SPES — Core
  * Plugin URI:        https://github.com/refo44/demo-revistalogos
  * Description:       Modelo de contenido de la Revista de Filosofía LOGO ET SPES: números, artículos, autores, taxonomías, rol Managing Editor, migración de contenido institucional y fixtures. El theme revistalogos solo presenta; este plugin es el dueño del dominio (ADR 0005).
- * Version:           0.2.15
+ * Version:           0.2.16
  * Requires at least: 6.4
  * Tested up to:      7.1
  * Requires PHP:      7.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_CORE_VERSION', '0.2.15' );
+define( 'REVISTALOGOS_CORE_VERSION', '0.2.16' );
 define( 'REVISTALOGOS_CORE_FILE', __FILE__ );
 define( 'REVISTALOGOS_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'REVISTALOGOS_CORE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- Quita los pies de ayuda de ISSN, Depósito Legal y Prefijo DOI en Ajustes → LOGO ET SPES.
- Plugin `revistalogos-core` **0.2.16**. Theme sin cambio (**0.2.8**).
- Versiones listas para etiquetar: proyecto **v0.3.11**.

## Test plan
- [x] `./tools/php-lint.sh`
- [x] `markdownlint-cli2`
- [x] `./tools/run-phpunit.sh --filter JournalIdentifierSettings`
- [ ] CI Tests green
- [ ] Tras merge: etiqueta anotada `v0.3.11` y FTPS desde esa etiqueta (ADR 0020)


Made with [Cursor](https://cursor.com)