### PR TITLE
chore(release): v0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+## [0.3.12] — 2026-09-11
+
+Release etiquetado para FTPS de producción (ADR 0020). Plugin
+`revistalogos-core` **0.2.17**. Theme `revistalogos` **0.2.9**.
+
 ### Changed
 - Theme `revistalogos` 0.2.9 y plugin `revistalogos-core` 0.2.17: la
   tarjeta Secciones se omite cuando el número no tiene secciones
@@ -548,7 +553,8 @@ con la infraestructura de gobierno del proyecto en su sitio.
 - El contenido editorial de la maqueta es demostrativo y **no** se publica en producción (ver `docs/17-implementation-order` §3.1).
 - `robots.txt` permanece en `Disallow: /` mientras el sitio es prototipo.
 
-[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.3.11...HEAD
+[Sin publicar]: https://github.com/refo44/demo-revistalogos/compare/v0.3.12...HEAD
+[0.3.12]: https://github.com/refo44/demo-revistalogos/compare/v0.3.11...v0.3.12
 [0.3.11]: https://github.com/refo44/demo-revistalogos/compare/v0.3.10...v0.3.11
 [0.3.10]: https://github.com/refo44/demo-revistalogos/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/refo44/demo-revistalogos/compare/v0.3.8...v0.3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 ### Changed
 - Theme `revistalogos` 0.2.9 y plugin `revistalogos-core` 0.2.17: la
   tarjeta Secciones se omite cuando el número no tiene secciones
-  asignadas (Vol. 1 Nº 1, decisión editorial).
+  asignadas (Vol. 1 Nº 1, decisión editorial). Estadísticas del Número
+  puede mostrar Visitas (WP Statistics, solo esa ficha) y Descargas
+  (PDF del número: Ver y Descargar). Cada tarjeta se oculta si el
+  valor es 0 o el plugin de analítica no está.
 
 ## [0.3.11] — 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ La versión vigente vive en `package.json` (fuente de verdad); ver `VERSION.md`.
 
 ## [Sin publicar]
 
+### Changed
+- Theme `revistalogos` 0.2.9 y plugin `revistalogos-core` 0.2.17: la
+  tarjeta Secciones se omite cuando el número no tiene secciones
+  asignadas (Vol. 1 Nº 1, decisión editorial).
+
 ## [0.3.11] — 2026-09-11
 
 Release etiquetado para FTPS de producción (ADR 0020). Plugin

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Versionado
 
-**Versión vigente: 0.3.11**
+**Versión vigente: 0.3.12**
 
 ## Fuente de verdad
 

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -1,12 +1,12 @@
 ---
 phase: "Fase 3"
 status: "classic_in_production"
-current_work_unit: "Identificadores digitales de revista (issue #58, BACKLOG 10) en rama"
-current_branch: "feat/journal-identifier-settings"
+current_work_unit: "Ocultar tarjeta Secciones cuando el número no usa secciones (rama fix/issue-section-stats)"
+current_branch: "fix/issue-section-stats"
 last_verified_commit: "8ebc8ee"
 last_checkpoint_commit: "8ebc8ee"
 updated_at: "2026-09-11"
-next_action: "PR de feat/journal-identifier-settings (issue #58). Tras merge: etiqueta anotada v0.3.10 y workflow_dispatch desde esa etiqueta (ADR 0020). Default OFF. No backfill. ADR 0017 WU7 not started."
+next_action: "PR de fix/issue-section-stats (ocultar Secciones si el conteo es 0). Plugin 0.2.17 / theme 0.2.9. Tras merge: release etiquetado nuevo y workflow_dispatch desde esa etiqueta (ADR 0020). Default OFF. No backfill. ADR 0017 WU7 not started."
 blocked: false
 ---
 
@@ -636,6 +636,11 @@ anotada `vMAJOR.MINOR.PATCH`. Merge a `main` no es un deploy. Gate en
 No disparo al pushear el tag. Plugin 0.2.8 live es excepción histórica
 (sin tag de proyecto de ese transfer). Próximo envío: release nuevo.
 
+**2026-09-11 (ocultar Secciones si el conteo es 0):** Vol. 1 Nº 1 no
+usa secciones por decisión editorial. El conteo derivado 0 es
+correcto; la tarjeta Secciones se omite. Plugin **0.2.17**, theme
+**0.2.9**. Suite: `tests/WordPress/IssueSectionStatsTest`.
+
 **2026-09-10 (ADR 0020, ref de rama):** el gate también rechaza
 `workflow_dispatch` desde `main` cuando HEAD está etiquetado. El ref
 tiene que ser `refs/tags/vX.Y.Z`. Harness
@@ -652,9 +657,11 @@ Recuperación institucional **ya hecha** (Pages reales permanentes). Carga
 editorial real en proceso desde wp-admin (**no** completa). Docker local:
 `http://localhost:8080` (WordPress 7.1, PHP **8.3**).
 
-Siguiente acción priorizada — **issue #58** en
-`feat/journal-identifier-settings`. Tras merge a `main`: etiqueta
-anotada `v0.3.10` (plugin 0.2.15 / theme 0.2.8) y
+Siguiente acción priorizada — **ocultar Secciones si el conteo es 0**
+en `fix/issue-section-stats` (plugin 0.2.17 / theme 0.2.9). Vol. 1 Nº 1
+no usa secciones por decisión editorial; el 0 es correcto y la tarjeta
+no debe mostrarse.
+Tras merge a `main`: release etiquetado nuevo y
 `workflow_dispatch` desde esa etiqueta (ADR 0020). **No** reabrir el
 checkpoint 0.2.8
 ([issue #9](https://github.com/refo44/demo-revistalogos/issues/9)

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -1,12 +1,12 @@
 ---
 phase: "Fase 3"
 status: "classic_in_production"
-current_work_unit: "Ocultar tarjeta Secciones cuando el número no usa secciones (rama fix/issue-section-stats)"
+current_work_unit: "Estadísticas del Número: ocultar Secciones/Visitas/Descargas si 0 (rama fix/issue-section-stats)"
 current_branch: "fix/issue-section-stats"
 last_verified_commit: "8ebc8ee"
 last_checkpoint_commit: "8ebc8ee"
 updated_at: "2026-09-11"
-next_action: "PR de fix/issue-section-stats (ocultar Secciones si el conteo es 0). Plugin 0.2.17 / theme 0.2.9. Tras merge: release etiquetado nuevo y workflow_dispatch desde esa etiqueta (ADR 0020). Default OFF. No backfill. ADR 0017 WU7 not started."
+next_action: "PR de fix/issue-section-stats (Secciones/Visitas/Descargas; ocultar si 0). Plugin 0.2.17 / theme 0.2.9. Tras merge: release etiquetado nuevo y workflow_dispatch desde esa etiqueta (ADR 0020). Default OFF. No backfill. ADR 0017 WU7 not started."
 blocked: false
 ---
 
@@ -636,10 +636,12 @@ anotada `vMAJOR.MINOR.PATCH`. Merge a `main` no es un deploy. Gate en
 No disparo al pushear el tag. Plugin 0.2.8 live es excepción histórica
 (sin tag de proyecto de ese transfer). Próximo envío: release nuevo.
 
-**2026-09-11 (ocultar Secciones si el conteo es 0):** Vol. 1 Nº 1 no
-usa secciones por decisión editorial. El conteo derivado 0 es
-correcto; la tarjeta Secciones se omite. Plugin **0.2.17**, theme
-**0.2.9**. Suite: `tests/WordPress/IssueSectionStatsTest`.
+**2026-09-11 (estadísticas del número):** Vol. 1 Nº 1 no usa
+secciones por decisión editorial; la tarjeta se omite si el conteo
+es 0. Visitas (WP Statistics, solo la ficha) y Descargas (PDF del
+número: Ver y Descargar) se muestran solo si el valor es > 0.
+Plugin **0.2.17**, theme **0.2.9**. Suites:
+`IssueSectionStatsTest`, `IssuePageViewsTest`, `IssuePdfDownloadsTest`.
 
 **2026-09-10 (ADR 0020, ref de rama):** el gate también rechaza
 `workflow_dispatch` desde `main` cuando HEAD está etiquetado. El ref
@@ -657,10 +659,10 @@ Recuperación institucional **ya hecha** (Pages reales permanentes). Carga
 editorial real en proceso desde wp-admin (**no** completa). Docker local:
 `http://localhost:8080` (WordPress 7.1, PHP **8.3**).
 
-Siguiente acción priorizada — **ocultar Secciones si el conteo es 0**
-en `fix/issue-section-stats` (plugin 0.2.17 / theme 0.2.9). Vol. 1 Nº 1
-no usa secciones por decisión editorial; el 0 es correcto y la tarjeta
-no debe mostrarse.
+Siguiente acción priorizada — **estadísticas del número** en
+`fix/issue-section-stats` (plugin 0.2.17 / theme 0.2.9). Ocultar
+Secciones/Visitas/Descargas si el valor es 0. Vol. 1 Nº 1 no usa
+secciones por decisión editorial.
 Tras merge a `main`: release etiquetado nuevo y
 `workflow_dispatch` desde esa etiqueta (ADR 0020). **No** reabrir el
 checkpoint 0.2.8

--- a/docs/fase3-execution-state.md
+++ b/docs/fase3-execution-state.md
@@ -1,12 +1,12 @@
 ---
 phase: "Fase 3"
 status: "classic_in_production"
-current_work_unit: "Estadísticas del Número: ocultar Secciones/Visitas/Descargas si 0 (rama fix/issue-section-stats)"
+current_work_unit: "Release v0.3.12 (estadísticas del número; plugin 0.2.17 / theme 0.2.9)"
 current_branch: "fix/issue-section-stats"
 last_verified_commit: "8ebc8ee"
 last_checkpoint_commit: "8ebc8ee"
 updated_at: "2026-09-11"
-next_action: "PR de fix/issue-section-stats (Secciones/Visitas/Descargas; ocultar si 0). Plugin 0.2.17 / theme 0.2.9. Tras merge: release etiquetado nuevo y workflow_dispatch desde esa etiqueta (ADR 0020). Default OFF. No backfill. ADR 0017 WU7 not started."
+next_action: "PR chore(release): v0.3.12. Tras merge: etiqueta anotada v0.3.12 sobre origin/main y workflow_dispatch desde esa etiqueta (ADR 0020). No despachar desde v0.3.11. Default OFF. No backfill. ADR 0017 WU7 not started."
 blocked: false
 ---
 
@@ -659,11 +659,11 @@ Recuperación institucional **ya hecha** (Pages reales permanentes). Carga
 editorial real en proceso desde wp-admin (**no** completa). Docker local:
 `http://localhost:8080` (WordPress 7.1, PHP **8.3**).
 
-Siguiente acción priorizada — **estadísticas del número** en
-`fix/issue-section-stats` (plugin 0.2.17 / theme 0.2.9). Ocultar
+Siguiente acción priorizada — PR **`chore(release): v0.3.12`**
+(`fix/issue-section-stats`; plugin 0.2.17 / theme 0.2.9). Ocultar
 Secciones/Visitas/Descargas si el valor es 0. Vol. 1 Nº 1 no usa
 secciones por decisión editorial.
-Tras merge a `main`: release etiquetado nuevo y
+Tras merge a `main`: etiqueta anotada `v0.3.12` sobre `origin/main` y
 `workflow_dispatch` desde esa etiqueta (ADR 0020). **No** reabrir el
 checkpoint 0.2.8
 ([issue #9](https://github.com/refo44/demo-revistalogos/issues/9)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revistalogos",
   "private": true,
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Revista de Filosofía LOGO ET SPES: static prototype (Fase 2) and WordPress theme/plugin (Fase 3).",
   "keywords": [
     "academic-journal",

--- a/tests/Features/estadisticas-secciones-del-numero.feature
+++ b/tests/Features/estadisticas-secciones-del-numero.feature
@@ -1,0 +1,20 @@
+# language: es
+Característica: Estadísticas de secciones del número
+  Como lectora de la revista
+  quiero ver la tarjeta Secciones solo cuando el número usa secciones
+  para no leer un cero cuando el comité no las asigna
+  # Vol. 1 Nº 1 no muestra secciones por decisión editorial.
+  # Ejecutan: tests/WordPress/IssueSectionStatsTest (composer test:wp).
+
+  Escenario: Sin secciones asignadas no se muestra la tarjeta
+    Dado un número publicado con artículos sin término de sección
+    Cuando se muestra la ficha pública del número
+    Entonces el conteo de secciones es 0
+    Y la tarjeta Secciones no aparece
+    Y sí aparecen Artículos y Autores
+
+  Escenario: Secciones asignadas se cuentan y se muestran
+    Dado un número con artículos en Ética y Metafísica
+    Cuando se muestra la ficha pública del número
+    Entonces el conteo de secciones es 2
+    Y la tarjeta Secciones aparece

--- a/tests/Features/estadisticas-visitas-descargas-del-numero.feature
+++ b/tests/Features/estadisticas-visitas-descargas-del-numero.feature
@@ -1,0 +1,26 @@
+# language: es
+Característica: Visitas y descargas en Estadísticas del Número
+  Como lectora de la revista
+  quiero ver las vistas de la ficha del número y las descargas de su PDF
+  para conocer el uso de ese volumen
+  # Visitas: WP Statistics gratis, solo esa URL. Se oculta si el plugin
+  # falta, está apagado, no hay datos o el valor es 0.
+  # Descargas: código propio; Ver PDF y Descargar PDF del número cuentan.
+  # No artículos. Sin visitantes únicos. Sin Páginas.
+  # Ejecutan: tests/Unit/IssuePageViewsTest (composer test:unit)
+  # y tests/WordPress/IssueSectionStatsTest,
+  # tests/WordPress/IssuePdfDownloadsTest (composer test:wp).
+
+  Escenario: Visitas y descargas del número se muestran si hay cifras
+    Dado un número con vistas de su propia ficha
+    Y descargas de su PDF completo
+    Cuando se muestran las Estadísticas del Número
+    Entonces aparece la tarjeta Visitas
+    Y aparece la tarjeta Descargas
+
+  Escenario: Sin visitas ni descargas no se muestran esas tarjetas
+    Dado un número sin visitas registradas
+    Y sin descargas de su PDF
+    Cuando se muestran las Estadísticas del Número
+    Entonces no aparece la tarjeta Visitas
+    Y no aparece la tarjeta Descargas

--- a/tests/Unit/IssuePageViewsTest.php
+++ b/tests/Unit/IssuePageViewsTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Public issue page-view count. Reads WP Statistics when present;
+ * never sums article views (Estadísticas del Número only).
+ *
+ * @package Revistalogos
+ */
+
+use PHPUnit\Framework\TestCase;
+use Revistalogos_Core\Issue_Page_Views;
+
+require_once dirname( __DIR__, 2 ) . '/wordpress/wp-content/plugins/revistalogos-core/includes/queries/class-issue-page-views.php';
+
+/**
+ * Protects the issue-only view number shown in issue statistics.
+ */
+class IssuePageViewsTest extends TestCase {
+
+	/**
+	 * Dado: WP Statistics reporta 15 visitas de la ficha del número.
+	 * Entonces: el conteo público es 15.
+	 */
+	public function test_count_uses_hits_of_the_issue_page_only() {
+		$hits_reader = static function ( $issue_id ) {
+			return 42 === $issue_id ? 15 : 99;
+		};
+
+		$this->assertSame( 15, Issue_Page_Views::count( 42, $hits_reader ) );
+	}
+
+	/**
+	 * Dado: el plugin no está, está apagado o no hay datos.
+	 * Entonces: el conteo es 0 (la tarjeta se oculta).
+	 */
+	public function test_count_is_zero_when_hits_reader_returns_nothing() {
+		$hits_reader = static function () {
+			return 0;
+		};
+
+		$this->assertSame( 0, Issue_Page_Views::count( 42, $hits_reader ) );
+	}
+
+	/**
+	 * Dado: un ID de número inválido.
+	 * Entonces: el conteo es 0 y no se consulta el lector.
+	 */
+	public function test_invalid_issue_id_is_zero_without_reading_hits() {
+		$called      = false;
+		$hits_reader = static function () use ( &$called ) {
+			$called = true;
+			return 15;
+		};
+
+		$this->assertSame( 0, Issue_Page_Views::count( 0, $hits_reader ) );
+		$this->assertFalse( $called );
+	}
+}

--- a/tests/WordPress/IssuePdfDownloadsTest.php
+++ b/tests/WordPress/IssuePdfDownloadsTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * First-party download count for the issue PDF only (ADR 0011:
+ * no paid WP Statistics addon). Ver and Descargar both count.
+ * Article PDFs are out of scope.
+ *
+ * @package Revistalogos
+ */
+
+use Revistalogos_Core\Issue_Pdf_Downloads;
+
+/**
+ * Protects increment and resolve of the numbered issue PDF.
+ */
+class IssuePdfDownloadsTest extends WP_UnitTestCase {
+
+	/**
+	 * Dado: un número publicado con PDF.
+	 * Cuando: se resuelve una descarga (Ver o Descargar).
+	 * Entonces: el conteo sube y la URL es la del adjunto.
+	 */
+	public function test_resolve_increments_and_returns_attachment_url() {
+		$issue_id = $this->make_published_issue_with_pdf();
+
+		$this->assertSame( 0, Issue_Pdf_Downloads::count( $issue_id ) );
+
+		$resolved = Issue_Pdf_Downloads::resolve( $issue_id );
+
+		$this->assertTrue( $resolved['ok'] );
+		$this->assertSame( 1, $resolved['count'] );
+		$this->assertSame( 1, Issue_Pdf_Downloads::count( $issue_id ) );
+		$this->assertNotSame( '', $resolved['url'] );
+	}
+
+	/**
+	 * Dado: un número publicado sin PDF.
+	 * Entonces: no hay descarga y el conteo no cambia.
+	 */
+	public function test_resolve_without_pdf_does_not_increment() {
+		$issue_id = (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'issue',
+				'post_status' => 'publish',
+				'post_title'  => 'Número sin PDF',
+			)
+		);
+
+		$resolved = Issue_Pdf_Downloads::resolve( $issue_id );
+
+		$this->assertFalse( $resolved['ok'] );
+		$this->assertSame( 0, Issue_Pdf_Downloads::count( $issue_id ) );
+	}
+
+	/**
+	 * @return int Issue ID.
+	 */
+	private function make_published_issue_with_pdf() {
+		$issue_id = (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'issue',
+				'post_status' => 'publish',
+				'post_title'  => 'Número con PDF',
+			)
+		);
+
+		$upload = wp_upload_bits( 'numero-qa.pdf', null, '%PDF-1.4 qa' );
+		$this->assertEmpty( $upload['error'] ?? '', wp_json_encode( $upload ) );
+
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_mime_type' => 'application/pdf',
+				'post_title'     => 'numero-qa',
+				'post_status'    => 'inherit',
+				'post_parent'    => $issue_id,
+			),
+			$upload['file'],
+			$issue_id
+		);
+		$this->assertNotWPError( $attachment_id );
+		update_post_meta( $issue_id, 'pdf_file', $attachment_id );
+
+		return $issue_id;
+	}
+}

--- a/tests/WordPress/IssueSectionStatsTest.php
+++ b/tests/WordPress/IssueSectionStatsTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Issue statistics count only assigned section terms. When that
+ * derived count is 0 (Vol. 1 Nº 1 has no editorial sections), the
+ * Secciones card is omitted so the page does not show a zero.
+ *
+ * @package Revistalogos
+ */
+
+use Revistalogos_Core\Queries;
+use Revistalogos_Core\Taxonomies;
+
+/**
+ * Protects the derived section count and its public visibility.
+ */
+class IssueSectionStatsTest extends WP_UnitTestCase {
+
+	/**
+	 * Dado: un número publicado con artículos sin término de sección
+	 * (Vol. 1 Nº 1: decisión editorial de no usar secciones).
+	 * Entonces: el conteo derivado es 0.
+	 */
+	public function test_articles_without_assigned_section_count_as_zero() {
+		$issue_id = $this->make_published_issue();
+		$this->make_published_article( $issue_id, 'Editorial sin sección' );
+		$this->make_published_article( $issue_id, 'Artículo sin sección' );
+
+		$this->assertSame( 0, Queries::issue_section_count( $issue_id ) );
+	}
+
+	/**
+	 * Dado: un número sin secciones asignadas.
+	 * Cuando: se muestra la ficha pública del número.
+	 * Entonces: no aparece la tarjeta Secciones.
+	 */
+	public function test_section_stat_is_hidden_when_count_is_zero() {
+		$issue_id = $this->make_published_issue();
+		$this->make_published_article( $issue_id, 'Artículo sin sección' );
+
+		$html = $this->render_issue_stats(
+			Queries::issue_articles( $issue_id ),
+			Queries::issue_section_count( $issue_id ),
+			1
+		);
+
+		$this->assertStringContainsString( 'Estadísticas del Número', $html );
+		$this->assertStringContainsString( 'Artículos', $html );
+		$this->assertStringNotContainsString( 'Secciones', $html );
+	}
+
+	/**
+	 * Dado: artículos en Ética y Metafísica.
+	 * Entonces: el número declara dos secciones y la tarjeta se muestra.
+	 */
+	public function test_assigned_sections_are_counted_and_shown() {
+		$issue_id = $this->make_published_issue();
+		$this->make_published_article( $issue_id, 'Ser y tiempo', 'Metafísica' );
+		$this->make_published_article( $issue_id, 'Ética aplicada', 'Ética' );
+
+		$this->assertSame( 2, Queries::issue_section_count( $issue_id ) );
+
+		$html = $this->render_issue_stats(
+			Queries::issue_articles( $issue_id ),
+			Queries::issue_section_count( $issue_id ),
+			2
+		);
+		$this->assertStringContainsString( 'Secciones', $html );
+		$this->assertStringContainsString( '>2</h3>', $html );
+	}
+
+	/**
+	 * Dado: un artículo en Ética y otro sin sección.
+	 * Entonces: solo cuenta la sección asignada.
+	 */
+	public function test_unassigned_articles_do_not_add_a_section() {
+		$issue_id = $this->make_published_issue();
+		$this->make_published_article( $issue_id, 'Ética aplicada', 'Ética' );
+		$this->make_published_article( $issue_id, 'Sin clasificar' );
+
+		$this->assertSame( 1, Queries::issue_section_count( $issue_id ) );
+	}
+
+	/**
+	 * Dado: varios artículos en la misma sección.
+	 * Entonces: esa sección cuenta una sola vez.
+	 */
+	public function test_several_articles_in_one_section_count_once() {
+		$issue_id = $this->make_published_issue();
+		$this->make_published_article( $issue_id, 'Primero', 'Ética' );
+		$this->make_published_article( $issue_id, 'Segundo', 'Ética' );
+
+		$this->assertSame( 1, Queries::issue_section_count( $issue_id ) );
+	}
+
+	/**
+	 * Dado: un número sin artículos publicados.
+	 * Entonces: el conteo de secciones es cero.
+	 */
+	public function test_issue_without_published_articles_has_zero_sections() {
+		$issue_id = $this->make_published_issue();
+
+		$this->assertSame( 0, Queries::issue_section_count( $issue_id ) );
+	}
+
+	/**
+	 * @param \WP_Post[] $articles      Published articles of the issue.
+	 * @param int        $section_count Derived assigned-section count.
+	 * @param int        $author_count  Distinct credited authors.
+	 * @return string Stats block HTML.
+	 */
+	private function render_issue_stats( $articles, $section_count, $author_count ) {
+		$args = array(
+			'article_count' => count( $articles ),
+			'section_count' => $section_count,
+			'author_count'  => $author_count,
+		);
+
+		ob_start();
+		require dirname( __DIR__, 2 ) . '/wordpress/wp-content/themes/revistalogos/template-parts/issue-stats.php';
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @return int Published issue ID.
+	 */
+	private function make_published_issue() {
+		return (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'issue',
+				'post_title'  => 'Vol. 1 Nº 1',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Factory publish of an article is demoted to draft unless a
+	 * published Author CPT is already assigned (plugin 0.2.5).
+	 *
+	 * @param int         $issue_id Issue ID.
+	 * @param string      $title    Article title.
+	 * @param string|null $section  Optional section term name.
+	 * @return int Article ID.
+	 */
+	private function make_published_article( $issue_id, $title, $section = null ) {
+		$author_id = (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'author',
+				'post_title'  => 'Autor de ' . $title,
+				'post_status' => 'publish',
+			)
+		);
+
+		$article_id = (int) self::factory()->post->create(
+			array(
+				'post_type'   => 'article',
+				'post_title'  => $title,
+				'post_status' => 'draft',
+			)
+		);
+		update_post_meta( $article_id, 'issue', $issue_id );
+		update_post_meta( $article_id, 'authors', array( $author_id ) );
+		wp_update_post(
+			array(
+				'ID'          => $article_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		if ( null !== $section ) {
+			wp_set_object_terms( $article_id, array( $section ), Taxonomies::SECTION );
+		}
+
+		return $article_id;
+	}
+}

--- a/tests/WordPress/IssueSectionStatsTest.php
+++ b/tests/WordPress/IssueSectionStatsTest.php
@@ -69,6 +69,30 @@ class IssueSectionStatsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Dado: la ficha del número tiene visitas y descargas de su PDF.
+	 * Entonces: esas tarjetas aparecen en Estadísticas del Número.
+	 */
+	public function test_issue_views_and_downloads_are_shown_when_positive() {
+		$html = $this->render_issue_stats( array( 1, 2 ), 0, 1, 15, 3 );
+
+		$this->assertStringContainsString( 'Visitas', $html );
+		$this->assertStringContainsString( '>15</h3>', $html );
+		$this->assertStringContainsString( 'Descargas', $html );
+		$this->assertStringContainsString( '>3</h3>', $html );
+	}
+
+	/**
+	 * Dado: aún no hay visitas ni descargas del número.
+	 * Entonces: esas tarjetas no aparecen (mismo criterio que Secciones).
+	 */
+	public function test_issue_views_and_downloads_are_hidden_when_zero() {
+		$html = $this->render_issue_stats( array( 1 ), 0, 1, 0, 0 );
+
+		$this->assertStringNotContainsString( 'Visitas', $html );
+		$this->assertStringNotContainsString( 'Descargas', $html );
+	}
+
+	/**
 	 * Dado: un artículo en Ética y otro sin sección.
 	 * Entonces: solo cuenta la sección asignada.
 	 */
@@ -103,16 +127,20 @@ class IssueSectionStatsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @param \WP_Post[] $articles      Published articles of the issue.
-	 * @param int        $section_count Derived assigned-section count.
-	 * @param int        $author_count  Distinct credited authors.
+	 * @param \WP_Post[] $articles       Published articles of the issue.
+	 * @param int        $section_count  Derived assigned-section count.
+	 * @param int        $author_count   Distinct credited authors.
+	 * @param int        $view_count     Issue page views.
+	 * @param int        $download_count Issue PDF downloads.
 	 * @return string Stats block HTML.
 	 */
-	private function render_issue_stats( $articles, $section_count, $author_count ) {
+	private function render_issue_stats( $articles, $section_count, $author_count, $view_count = 0, $download_count = 0 ) {
 		$args = array(
-			'article_count' => count( $articles ),
-			'section_count' => $section_count,
-			'author_count'  => $author_count,
+			'article_count'  => count( $articles ),
+			'section_count'  => $section_count,
+			'author_count'   => $author_count,
+			'view_count'     => $view_count,
+			'download_count' => $download_count,
 		);
 
 		ob_start();

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/class-plugin.php
@@ -52,6 +52,7 @@ class Plugin {
 		Article_Pdf_Publication_Enforcer::register_hooks();
 		Native_Sitemap::register_hooks();
 		Llms_Txt::register_hooks();
+		Issue_Pdf_Downloads::register_hooks();
 
 		// Idempotent upgrade: late on init so CPT rewrite args are
 		// registered before a version-gated rewrite flush.
@@ -86,6 +87,8 @@ class Plugin {
 		require_once $includes . 'relationships/class-relationships.php';
 		require_once $includes . 'roles/class-roles.php';
 		require_once $includes . 'queries/class-queries.php';
+		require_once $includes . 'queries/class-issue-page-views.php';
+		require_once $includes . 'queries/class-issue-pdf-downloads.php';
 		require_once $includes . 'integrations/class-comments-disabler.php';
 		require_once $includes . 'integrations/class-contact-form-integration.php';
 		require_once $includes . 'integrations/class-native-sitemap.php';

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/queries/class-issue-page-views.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/queries/class-issue-page-views.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Public page-view count for one issue permalink. Reads WP Statistics
+ * when the free plugin is active; never sums article views.
+ *
+ * @package Revistalogos_Core
+ */
+
+namespace Revistalogos_Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adapter around wp_statistics_pages for Estadísticas del Número.
+ */
+class Issue_Page_Views {
+
+	/**
+	 * Total recorded views of the issue URL. 0 when the plugin is
+	 * missing, inactive, or has no rows for that ID.
+	 *
+	 * @param int           $issue_id    Issue post ID.
+	 * @param callable|null $hits_reader Optional reader (id): int for tests.
+	 * @return int
+	 */
+	public static function count( $issue_id, $hits_reader = null ) {
+		$issue_id = (int) $issue_id;
+
+		if ( $issue_id < 1 ) {
+			return 0;
+		}
+
+		if ( ! is_callable( $hits_reader ) ) {
+			$hits_reader = array( __CLASS__, 'read_installed_hits' );
+		}
+
+		$hits = call_user_func( $hits_reader, $issue_id );
+
+		if ( ! is_numeric( $hits ) ) {
+			return 0;
+		}
+
+		return max( 0, (int) $hits );
+	}
+
+	/**
+	 * @param int $issue_id Issue post ID.
+	 * @return int
+	 */
+	public static function read_installed_hits( $issue_id ) {
+		if ( ! function_exists( 'wp_statistics_pages' ) ) {
+			return 0;
+		}
+
+		return wp_statistics_pages( 'total', '', $issue_id );
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/queries/class-issue-pdf-downloads.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/queries/class-issue-pdf-downloads.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * First-party download count for the issue PDF (ADR 0011: no paid
+ * WP Statistics addon). Ver PDF and Descargar PDF share this path.
+ *
+ * @package Revistalogos_Core
+ */
+
+namespace Revistalogos_Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Counts and serves the complete-issue PDF.
+ */
+class Issue_Pdf_Downloads {
+
+	const META_KEY  = '_les_issue_pdf_downloads';
+	const QUERY_VAR = 'revistalogos_issue_pdf';
+
+	/**
+	 * Register the public counted-download endpoint.
+	 */
+	public static function register_hooks() {
+		add_filter( 'query_vars', array( __CLASS__, 'register_query_var' ) );
+		add_action( 'template_redirect', array( __CLASS__, 'maybe_serve' ) );
+	}
+
+	/**
+	 * @param string[] $vars Public query vars.
+	 * @return string[]
+	 */
+	public static function register_query_var( $vars ) {
+		$vars[] = self::QUERY_VAR;
+
+		return $vars;
+	}
+
+	/**
+	 * @param int $issue_id Issue post ID.
+	 * @return int
+	 */
+	public static function count( $issue_id ) {
+		$issue_id = absint( $issue_id );
+
+		if ( $issue_id < 1 ) {
+			return 0;
+		}
+
+		return absint( get_post_meta( $issue_id, self::META_KEY, true ) );
+	}
+
+	/**
+	 * Public URL that increments then redirects to the attachment.
+	 * Empty when the issue has no PDF.
+	 *
+	 * @param int $issue_id Issue post ID.
+	 * @return string
+	 */
+	public static function counted_url( $issue_id ) {
+		$issue_id = absint( $issue_id );
+
+		if ( '' === self::attachment_url( $issue_id ) ) {
+			return '';
+		}
+
+		return add_query_arg( self::QUERY_VAR, $issue_id, home_url( '/' ) );
+	}
+
+	/**
+	 * Increment and return the attachment URL, or refuse.
+	 *
+	 * @param int $issue_id Issue post ID.
+	 * @return array{ok: bool, url?: string, count?: int}
+	 */
+	public static function resolve( $issue_id ) {
+		$url = self::attachment_url( $issue_id );
+
+		if ( '' === $url ) {
+			return array( 'ok' => false );
+		}
+
+		$count = self::increment( $issue_id );
+
+		return array(
+			'ok'    => true,
+			'url'   => $url,
+			'count' => $count,
+		);
+	}
+
+	/**
+	 * Serve a counted download when the query var is present.
+	 */
+	public static function maybe_serve() {
+		$issue_id = absint( get_query_var( self::QUERY_VAR ) );
+
+		if ( $issue_id < 1 ) {
+			return;
+		}
+
+		$resolved = self::resolve( $issue_id );
+
+		if ( ! $resolved['ok'] ) {
+			status_header( 404 );
+			nocache_headers();
+			exit;
+		}
+
+		wp_safe_redirect( $resolved['url'], 302 );
+		exit;
+	}
+
+	/**
+	 * @param int $issue_id Issue post ID.
+	 * @return int New total.
+	 */
+	private static function increment( $issue_id ) {
+		$next = self::count( $issue_id ) + 1;
+		update_post_meta( $issue_id, self::META_KEY, $next );
+
+		return $next;
+	}
+
+	/**
+	 * @param int $issue_id Issue post ID.
+	 * @return string Attachment URL or empty.
+	 */
+	private static function attachment_url( $issue_id ) {
+		$issue_id = absint( $issue_id );
+		$issue    = get_post( $issue_id );
+
+		if ( ! $issue || Content_Types::ISSUE !== $issue->post_type || 'publish' !== $issue->post_status ) {
+			return '';
+		}
+
+		$attachment_id = absint( get_post_meta( $issue_id, 'pdf_file', true ) );
+
+		if ( $attachment_id < 1 ) {
+			return '';
+		}
+
+		$url = wp_get_attachment_url( $attachment_id );
+
+		return $url ? $url : '';
+	}
+}

--- a/wordpress/wp-content/plugins/revistalogos-core/includes/queries/class-queries.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/includes/queries/class-queries.php
@@ -69,6 +69,32 @@ class Queries {
 	}
 
 	/**
+	 * Distinct assigned section terms among an issue's published
+	 * articles. Articles without a section term do not count — a zero
+	 * means the issue does not use sections. Count is derived, never
+	 * stored (docs/03, ADR 0005).
+	 *
+	 * @param int $issue_id Issue post ID.
+	 * @return int
+	 */
+	public static function issue_section_count( $issue_id ) {
+		$section_ids = array();
+
+		foreach ( self::issue_articles( $issue_id ) as $article ) {
+			$terms = get_the_terms( $article, Taxonomies::SECTION );
+			if ( ! is_array( $terms ) ) {
+				continue;
+			}
+
+			foreach ( $terms as $term ) {
+				$section_ids[ $term->term_id ] = true;
+			}
+		}
+
+		return count( $section_ids );
+	}
+
+	/**
 	 * Published articles credited to an author profile.
 	 *
 	 * @param int $author_id Author post ID.

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -3,7 +3,7 @@ Contributors: cenfiss
 Requires at least: 6.4
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 0.2.16
+Stable tag: 0.2.17
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,10 @@ Fase 3: los campos `issn`, `doi` y `orcid` son almacenamiento base inerte;
 la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 
 == Changelog ==
+
+= 0.2.17 =
+* Derived issue section count ignores articles with no section term so
+  the theme can hide the Secciones card when the issue uses none.
 
 = 0.2.16 =
 * Settings → LOGO ET SPES identifier fields have no per-field captions.

--- a/wordpress/wp-content/plugins/revistalogos-core/readme.txt
+++ b/wordpress/wp-content/plugins/revistalogos-core/readme.txt
@@ -41,6 +41,8 @@ la validación/visualización DOI-ORCID es Fase 4 (ADR 0013).
 = 0.2.17 =
 * Derived issue section count ignores articles with no section term so
   the theme can hide the Secciones card when the issue uses none.
+  Issue stats can show page views (WP Statistics) and issue-PDF
+  downloads (Ver and Descargar). Cards hide at 0.
 
 = 0.2.16 =
 * Settings → LOGO ET SPES identifier fields have no per-field captions.

--- a/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
+++ b/wordpress/wp-content/plugins/revistalogos-core/revistalogos-core.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Revista LOGO ET SPES — Core
  * Plugin URI:        https://github.com/refo44/demo-revistalogos
  * Description:       Modelo de contenido de la Revista de Filosofía LOGO ET SPES: números, artículos, autores, taxonomías, rol Managing Editor, migración de contenido institucional y fixtures. El theme revistalogos solo presenta; este plugin es el dueño del dominio (ADR 0005).
- * Version:           0.2.16
+ * Version:           0.2.17
  * Requires at least: 6.4
  * Tested up to:      7.1
  * Requires PHP:      7.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_CORE_VERSION', '0.2.16' );
+define( 'REVISTALOGOS_CORE_VERSION', '0.2.17' );
 define( 'REVISTALOGOS_CORE_FILE', __FILE__ );
 define( 'REVISTALOGOS_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'REVISTALOGOS_CORE_URL', plugin_dir_url( __FILE__ ) );

--- a/wordpress/wp-content/themes/revistalogos/functions.php
+++ b/wordpress/wp-content/themes/revistalogos/functions.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'REVISTALOGOS_THEME_VERSION', '0.2.8' );
+define( 'REVISTALOGOS_THEME_VERSION', '0.2.9' );
 
 require_once get_template_directory() . '/inc/template-tags.php';
 require_once get_template_directory() . '/inc/class-nav-walker.php';

--- a/wordpress/wp-content/themes/revistalogos/inc/template-tags.php
+++ b/wordpress/wp-content/themes/revistalogos/inc/template-tags.php
@@ -75,6 +75,52 @@ function revistalogos_issue_section_count( $issue_id ) {
 }
 
 /**
+ * Recorded views of the issue permalink (0 without the plugin or data).
+ *
+ * @param int $issue_id Issue ID.
+ * @return int
+ */
+function revistalogos_issue_page_views( $issue_id ) {
+	if ( ! class_exists( '\Revistalogos_Core\Issue_Page_Views' ) ) {
+		return 0;
+	}
+
+	return Revistalogos_Core\Issue_Page_Views::count( $issue_id );
+}
+
+/**
+ * Recorded downloads of the issue PDF (0 without the plugin).
+ *
+ * @param int $issue_id Issue ID.
+ * @return int
+ */
+function revistalogos_issue_pdf_downloads( $issue_id ) {
+	if ( ! class_exists( '\Revistalogos_Core\Issue_Pdf_Downloads' ) ) {
+		return 0;
+	}
+
+	return Revistalogos_Core\Issue_Pdf_Downloads::count( $issue_id );
+}
+
+/**
+ * Counted URL for Ver/Descargar the issue PDF; falls back to the file.
+ *
+ * @param int $issue_id Issue ID.
+ * @return string
+ */
+function revistalogos_issue_pdf_url( $issue_id ) {
+	if ( class_exists( '\Revistalogos_Core\Issue_Pdf_Downloads' ) ) {
+		$counted = Revistalogos_Core\Issue_Pdf_Downloads::counted_url( $issue_id );
+
+		if ( $counted ) {
+			return $counted;
+		}
+	}
+
+	return revistalogos_meta_attachment_url( $issue_id );
+}
+
+/**
  * Author profiles credited on an article.
  *
  * @param int $article_id Article ID.

--- a/wordpress/wp-content/themes/revistalogos/inc/template-tags.php
+++ b/wordpress/wp-content/themes/revistalogos/inc/template-tags.php
@@ -61,6 +61,20 @@ function revistalogos_issue_articles( $issue_id, $limit = -1 ) {
 }
 
 /**
+ * Distinct assigned section terms of an issue (plugin-derived; 0 without it).
+ *
+ * @param int $issue_id Issue ID.
+ * @return int
+ */
+function revistalogos_issue_section_count( $issue_id ) {
+	if ( ! revistalogos_core_active() ) {
+		return 0;
+	}
+
+	return Revistalogos_Core\Queries::issue_section_count( $issue_id );
+}
+
+/**
  * Author profiles credited on an article.
  *
  * @param int $article_id Article ID.

--- a/wordpress/wp-content/themes/revistalogos/single-issue.php
+++ b/wordpress/wp-content/themes/revistalogos/single-issue.php
@@ -21,7 +21,7 @@ while ( have_posts() ) :
 	$revistalogos_issn          = get_post_meta( $revistalogos_issue_id, 'issn', true );
 	$revistalogos_doi           = get_post_meta( $revistalogos_issue_id, 'doi', true );
 	$revistalogos_published     = get_post_meta( $revistalogos_issue_id, 'date_published', true );
-	$revistalogos_pdf_url       = revistalogos_meta_attachment_url( $revistalogos_issue_id );
+	$revistalogos_pdf_url       = revistalogos_issue_pdf_url( $revistalogos_issue_id );
 	$revistalogos_issue_archive = get_post_type_archive_link( 'issue' );
 
 	$revistalogos_articles = revistalogos_issue_articles( $revistalogos_issue_id );
@@ -35,10 +35,12 @@ while ( have_posts() ) :
 		}
 	}
 
-	// Derived stats (never stored: ADR 0005). Section count is assigned
-	// terms only; the Secciones card is omitted when that count is 0.
-	$revistalogos_section_count = revistalogos_issue_section_count( $revistalogos_issue_id );
-	$revistalogos_author_ids    = array();
+	// Derived stats (never stored: ADR 0005). Secciones, Visitas and
+	// Descargas cards are omitted when that count is 0.
+	$revistalogos_section_count  = revistalogos_issue_section_count( $revistalogos_issue_id );
+	$revistalogos_view_count     = revistalogos_issue_page_views( $revistalogos_issue_id );
+	$revistalogos_download_count = revistalogos_issue_pdf_downloads( $revistalogos_issue_id );
+	$revistalogos_author_ids     = array();
 	foreach ( $revistalogos_articles as $revistalogos_item ) {
 		$revistalogos_ids = get_post_meta( $revistalogos_item->ID, 'authors', true );
 		if ( is_array( $revistalogos_ids ) ) {
@@ -118,9 +120,11 @@ while ( have_posts() ) :
 				'template-parts/issue-stats',
 				null,
 				array(
-					'article_count' => count( $revistalogos_articles ),
-					'section_count' => $revistalogos_section_count,
-					'author_count'  => count( $revistalogos_author_ids ),
+					'article_count'  => count( $revistalogos_articles ),
+					'section_count'  => $revistalogos_section_count,
+					'author_count'   => count( $revistalogos_author_ids ),
+					'view_count'     => $revistalogos_view_count,
+					'download_count' => $revistalogos_download_count,
 				)
 			);
 			?>

--- a/wordpress/wp-content/themes/revistalogos/single-issue.php
+++ b/wordpress/wp-content/themes/revistalogos/single-issue.php
@@ -35,17 +35,11 @@ while ( have_posts() ) :
 		}
 	}
 
-	// Derived stats (never stored: ADR 0005).
-	$revistalogos_section_ids = array();
-	$revistalogos_author_ids  = array();
+	// Derived stats (never stored: ADR 0005). Section count is assigned
+	// terms only; the Secciones card is omitted when that count is 0.
+	$revistalogos_section_count = revistalogos_issue_section_count( $revistalogos_issue_id );
+	$revistalogos_author_ids    = array();
 	foreach ( $revistalogos_articles as $revistalogos_item ) {
-		$revistalogos_terms = get_the_terms( $revistalogos_item, 'section' );
-		if ( is_array( $revistalogos_terms ) ) {
-			foreach ( $revistalogos_terms as $revistalogos_term ) {
-				$revistalogos_section_ids[ $revistalogos_term->term_id ] = true;
-			}
-		}
-
 		$revistalogos_ids = get_post_meta( $revistalogos_item->ID, 'authors', true );
 		if ( is_array( $revistalogos_ids ) ) {
 			foreach ( $revistalogos_ids as $revistalogos_author_id ) {
@@ -119,25 +113,17 @@ while ( have_posts() ) :
 			<?php endif; ?>
 
 			<!-- Estadísticas del número -->
-			<?php if ( $revistalogos_articles ) : ?>
-				<section class="single-issue__stats">
-					<h2><?php esc_html_e( 'Estadísticas del Número', 'revistalogos' ); ?></h2>
-					<div class="grid grid-cols-4 gap-4">
-						<div class="card text-center">
-							<h3><?php echo esc_html( (string) count( $revistalogos_articles ) ); ?></h3>
-							<p><?php esc_html_e( 'Artículos', 'revistalogos' ); ?></p>
-						</div>
-						<div class="card text-center">
-							<h3><?php echo esc_html( (string) count( $revistalogos_section_ids ) ); ?></h3>
-							<p><?php esc_html_e( 'Secciones', 'revistalogos' ); ?></p>
-						</div>
-						<div class="card text-center">
-							<h3><?php echo esc_html( (string) count( $revistalogos_author_ids ) ); ?></h3>
-							<p><?php esc_html_e( 'Autores', 'revistalogos' ); ?></p>
-						</div>
-					</div>
-				</section>
-			<?php endif; ?>
+			<?php
+			get_template_part(
+				'template-parts/issue-stats',
+				null,
+				array(
+					'article_count' => count( $revistalogos_articles ),
+					'section_count' => $revistalogos_section_count,
+					'author_count'  => count( $revistalogos_author_ids ),
+				)
+			);
+			?>
 		</div>
 	</main>
 	<?php

--- a/wordpress/wp-content/themes/revistalogos/style.css
+++ b/wordpress/wp-content/themes/revistalogos/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/refo44/demo-revistalogos
 Author: CENFISS
 Author URI: https://cenfiss.net
 Description: Theme clásico de la Revista de Filosofía LOGO ET SPES. Adaptación sin rediseño de la maqueta estática validada (ADR 0001/0002); todo el CSS vive en assets/css/main.css y sus módulos (ADR 0003). El dominio de contenido lo define el plugin revistalogos-core.
-Version: 0.2.8
+Version: 0.2.9
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4

--- a/wordpress/wp-content/themes/revistalogos/template-parts/issue-card.php
+++ b/wordpress/wp-content/themes/revistalogos/template-parts/issue-card.php
@@ -92,18 +92,9 @@ $revistalogos_card_class = 'card issue-card' . ( $revistalogos_featured ? ' fron
 
 		<?php
 		if ( $revistalogos_show_stats ) :
-			$revistalogos_articles = revistalogos_issue_articles( $revistalogos_issue_id );
-			$revistalogos_count    = count( $revistalogos_articles );
-
-			$revistalogos_sections = array();
-			foreach ( $revistalogos_articles as $revistalogos_article_item ) {
-				$revistalogos_terms = get_the_terms( $revistalogos_article_item, 'section' );
-				if ( is_array( $revistalogos_terms ) ) {
-					foreach ( $revistalogos_terms as $revistalogos_term ) {
-						$revistalogos_sections[ $revistalogos_term->term_id ] = true;
-					}
-				}
-			}
+			$revistalogos_articles      = revistalogos_issue_articles( $revistalogos_issue_id );
+			$revistalogos_count         = count( $revistalogos_articles );
+			$revistalogos_section_count = revistalogos_issue_section_count( $revistalogos_issue_id );
 
 			if ( $revistalogos_count > 0 ) :
 				?>
@@ -114,12 +105,12 @@ $revistalogos_card_class = 'card issue-card' . ( $revistalogos_featured ? ' fron
 					echo esc_html( sprintf( _n( '%d artículo', '%d artículos', $revistalogos_count, 'revistalogos' ), $revistalogos_count ) );
 					?>
 					</strong></span>
-					<?php if ( count( $revistalogos_sections ) > 0 ) : ?>
+					<?php if ( $revistalogos_section_count > 0 ) : ?>
 						&bull;
 						<span><strong>
 						<?php
 						/* translators: %d: number of sections. */
-						echo esc_html( sprintf( _n( '%d sección', '%d secciones', count( $revistalogos_sections ), 'revistalogos' ), count( $revistalogos_sections ) ) );
+						echo esc_html( sprintf( _n( '%d sección', '%d secciones', $revistalogos_section_count, 'revistalogos' ), $revistalogos_section_count ) );
 						?>
 						</strong></span>
 					<?php endif; ?>

--- a/wordpress/wp-content/themes/revistalogos/template-parts/issue-card.php
+++ b/wordpress/wp-content/themes/revistalogos/template-parts/issue-card.php
@@ -31,7 +31,7 @@ $revistalogos_label     = revistalogos_issue_label( $revistalogos_issue_id );
 $revistalogos_year      = absint( get_post_meta( $revistalogos_issue_id, 'year', true ) );
 $revistalogos_issn      = get_post_meta( $revistalogos_issue_id, 'issn', true );
 $revistalogos_doi       = get_post_meta( $revistalogos_issue_id, 'doi', true );
-$revistalogos_pdf_url   = revistalogos_meta_attachment_url( $revistalogos_issue_id );
+$revistalogos_pdf_url   = revistalogos_issue_pdf_url( $revistalogos_issue_id );
 $revistalogos_permalink = get_permalink( $revistalogos_issue );
 $revistalogos_title     = get_the_title( $revistalogos_issue );
 

--- a/wordpress/wp-content/themes/revistalogos/template-parts/issue-stats.php
+++ b/wordpress/wp-content/themes/revistalogos/template-parts/issue-stats.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Derived issue statistics. The Secciones card is omitted when the
+ * issue has no assigned section terms.
+ *
+ * Args:
+ * - article_count (int)
+ * - section_count (int)
+ * - author_count (int)
+ *
+ * @package Revistalogos
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$revistalogos_article_count = isset( $args['article_count'] ) ? absint( $args['article_count'] ) : 0;
+$revistalogos_section_count = isset( $args['section_count'] ) ? absint( $args['section_count'] ) : 0;
+$revistalogos_author_count  = isset( $args['author_count'] ) ? absint( $args['author_count'] ) : 0;
+
+if ( $revistalogos_article_count < 1 ) {
+	return;
+}
+?>
+<section class="single-issue__stats">
+	<h2><?php esc_html_e( 'Estadísticas del Número', 'revistalogos' ); ?></h2>
+	<div class="grid grid-cols-4 gap-4">
+		<div class="card text-center">
+			<h3><?php echo esc_html( (string) $revistalogos_article_count ); ?></h3>
+			<p><?php esc_html_e( 'Artículos', 'revistalogos' ); ?></p>
+		</div>
+		<?php if ( $revistalogos_section_count > 0 ) : ?>
+			<div class="card text-center">
+				<h3><?php echo esc_html( (string) $revistalogos_section_count ); ?></h3>
+				<p><?php esc_html_e( 'Secciones', 'revistalogos' ); ?></p>
+			</div>
+		<?php endif; ?>
+		<div class="card text-center">
+			<h3><?php echo esc_html( (string) $revistalogos_author_count ); ?></h3>
+			<p><?php esc_html_e( 'Autores', 'revistalogos' ); ?></p>
+		</div>
+	</div>
+</section>

--- a/wordpress/wp-content/themes/revistalogos/template-parts/issue-stats.php
+++ b/wordpress/wp-content/themes/revistalogos/template-parts/issue-stats.php
@@ -7,6 +7,8 @@
  * - article_count (int)
  * - section_count (int)
  * - author_count (int)
+ * - view_count (int)
+ * - download_count (int)
  *
  * @package Revistalogos
  */
@@ -15,9 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$revistalogos_article_count = isset( $args['article_count'] ) ? absint( $args['article_count'] ) : 0;
-$revistalogos_section_count = isset( $args['section_count'] ) ? absint( $args['section_count'] ) : 0;
-$revistalogos_author_count  = isset( $args['author_count'] ) ? absint( $args['author_count'] ) : 0;
+$revistalogos_article_count  = isset( $args['article_count'] ) ? absint( $args['article_count'] ) : 0;
+$revistalogos_section_count  = isset( $args['section_count'] ) ? absint( $args['section_count'] ) : 0;
+$revistalogos_author_count   = isset( $args['author_count'] ) ? absint( $args['author_count'] ) : 0;
+$revistalogos_view_count     = isset( $args['view_count'] ) ? absint( $args['view_count'] ) : 0;
+$revistalogos_download_count = isset( $args['download_count'] ) ? absint( $args['download_count'] ) : 0;
 
 if ( $revistalogos_article_count < 1 ) {
 	return;
@@ -40,5 +44,17 @@ if ( $revistalogos_article_count < 1 ) {
 			<h3><?php echo esc_html( (string) $revistalogos_author_count ); ?></h3>
 			<p><?php esc_html_e( 'Autores', 'revistalogos' ); ?></p>
 		</div>
+		<?php if ( $revistalogos_view_count > 0 ) : ?>
+			<div class="card text-center">
+				<h3><?php echo esc_html( (string) $revistalogos_view_count ); ?></h3>
+				<p><?php esc_html_e( 'Visitas', 'revistalogos' ); ?></p>
+			</div>
+		<?php endif; ?>
+		<?php if ( $revistalogos_download_count > 0 ) : ?>
+			<div class="card text-center">
+				<h3><?php echo esc_html( (string) $revistalogos_download_count ); ?></h3>
+				<p><?php esc_html_e( 'Descargas', 'revistalogos' ); ?></p>
+			</div>
+		<?php endif; ?>
 	</div>
 </section>


### PR DESCRIPTION
## Summary
- Oculta las tarjetas Secciones, Visitas y Descargas en Estadísticas del Número cuando el valor es 0 (Vol. 1 Nº 1 no usa secciones por decisión editorial).
- Visitas (WP Statistics, solo esa ficha) y Descargas (contador propio del PDF del número: Ver y Descargar).
- Plugin `revistalogos-core` **0.2.17**. Theme `revistalogos` **0.2.9**. Proyecto **v0.3.12**.

## Test plan
- [x] `markdownlint-cli2` (65 files, 0 errors)
- [x] `./tools/run-phpunit.sh tests/Unit/IssuePageViewsTest.php`
- [x] `./tools/run-phpunit-wp.sh tests/WordPress/IssueSectionStatsTest.php tests/WordPress/IssuePdfDownloadsTest.php`
- [ ] CI Tests green
- [ ] Tras merge: etiqueta anotada `v0.3.12` sobre `origin/main` y FTPS desde esa etiqueta (ADR 0020). No despachar desde `v0.3.11`.


Made with [Cursor](https://cursor.com)